### PR TITLE
Handle regexp in throws. Fixes #8

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -271,12 +271,24 @@ Test.prototype['throws'] = function (fn, expected, msg, extra) {
     }
     catch (err) {
         caught = { error : err };
+        var message = err.message;
+        delete err.message;
+        err.message = message;
     }
-    this._assert(caught, {
+
+    var passed = caught;
+
+    if (expected instanceof RegExp) {
+        passed = expected.test(caught && caught.error);
+        expected = String(expected);
+    }
+
+    this._assert(passed, {
         message : defined(msg, 'should throw'),
         operator : 'throws',
         actual : caught && caught.error,
         expected : expected,
+        error: !passed && caught && caught.error,
         extra : extra
     });
 };


### PR DESCRIPTION
This is similar to how assert in node handles it.

We also have a little patch that removes the message property and re-sets it.

This means it's now an own enumerable property and will show up in TAP output.
