### PR TITLE
don't make tape harder to use than it has to be

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var path = require('path');
+process.argv.slice(2).forEach(function(file) {
+    require(path.resolve(process.cwd(), file));
+});
+
+// vim: ft=javascript

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version" : "0.2.2",
     "description" : "tap-producing test harness for node and browsers",
     "main" : "index.js",
-    "bin" : {},
+    "bin" : "./bin/tape",
     "directories" : {
         "example" : "example",
         "test" : "test"


### PR DESCRIPTION
Tape is super simple. Nothing more is needed. However doing `node test/*.js` in package.json does not work. This adds a tiny bin file to tape to run your damn tests (since tape is a testing framework).

`tape test/*.js` That is it. No flags, no nothing. Just less hassle when using tape. As it should be!
