### PR TITLE
Add the only property back to the exported test function

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,13 +17,16 @@ var nextTick = typeof setImmediate !== 'undefined'
 exports = module.exports = (function () {
     var harness;
     var lazyLoad = function () {
-        if (!harness) {
-            harness = createExitHarness();
-            lazyLoad.only = harness.only;
-        }
+        if (!harness) harness = createExitHarness();
 
         return harness.apply(this, arguments);
     };
+
+    lazyLoad.only = function () {
+        if (!harness) harness = createExitHarness();
+
+        return harness.only.apply(this, arguments);
+    }
 
     return lazyLoad
 })();


### PR DESCRIPTION
Your lazy loading of the module.exports broke back compat with
the only property on the test object.

This brings the only method back so people can do

``` js
var test = require("tape")

test.only("run this test", function (assert) {
  /* my test */
})
```
