### PR TITLE
do not call process.exit() on uncaught exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,17 @@ function createExitHarness (conf) {
     if (conf.exit === false) return harness;
     if (!canEmitExit || !canExit) return harness;
     
+    var _error;
+
+    process.on('uncaughtException', function (err) {
+        _error = err
+    })
+
     process.on('exit', function (code) {
+        if (_error) {
+            return
+        }
+
         if (!ended) {
             for (var i = 0; i < harness._tests.length; i++) {
                 var t = harness._tests[i];


### PR DESCRIPTION
This fixes #35

when an uncaught exception occurs node triggers the `process.on("exit")` event. Because that handler calls `process.exit(n)` the process does not exit normally with the expected asynchronously thrown error like you would expect.

With this patch you can throw async errors and it crashes your process like you would expect.
