### PR TITLE
re-throw error to get it to show

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ function createExitHarness (conf) {
 
     process.on('uncaughtException', function (err) {
         _error = err
+        
+        throw err
     })
 
     process.on('exit', function (code) {


### PR DESCRIPTION
There are some more edgecases :(

You have to rethrow the error in the uncaught listener for it to actually print.
