### PR TITLE
test.only should not run any other test blocks

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -194,13 +194,13 @@ function getSerialize () {
 }
 
 function getNextTest(results) {
-    if (!results.only)
+    if (!results.only) {
         return results.tests.shift();
     }
 
     do {
         var t = results.tests.shift();
-        if (tick) {
+        if (!t) {
             return null;
         }
         if (results.only === t.name) {


### PR DESCRIPTION
Previously test.only would run every test block but only output
the TAP result of the the one marked as only.

Now it won't run every function.

This is useful for wanting to run just one `test()` block in a
file for debugging / printing / performance / noise purposes.

I will add tests for this soonish.
