### PR TITLE
make assert.end behave like a node callback

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -41,6 +41,7 @@ function Test (name_, opts_, cb_) {
     this._cb = cb;
     this._progeny = [];
     this._ok = true;
+    this.end = this.end.bind(this);
 }
 
 Test.prototype.run = function () {
@@ -74,8 +75,12 @@ Test.prototype.plan = function (n) {
     this.emit('plan', n);
 };
 
-Test.prototype.end = function () {
+Test.prototype.end = function (err) {
     var self = this;
+    if (arguments.length === 1) {
+        this.ifError(err);
+    }
+
     if (this._progeny.length) {
         var t = this._progeny.shift();
         t.on('end', function () { self.end() });

--- a/test/end-as-callback.js
+++ b/test/end-as-callback.js
@@ -1,0 +1,66 @@
+var tap = require("tap");
+var tape = require("../");
+
+tap.test("tape assert.end as callback", function (tt) {
+    var test = tape.createHarness({ exit: false })
+    var tc = tap.createConsumer()
+
+    var rows = []
+    tc.on("data", function (r) { rows.push(r) })
+    tc.on("end", function () {
+        var rs = rows.map(function (r) {
+            return r && typeof r === "object" ?
+                { id: r.id, ok: r.ok, name: r.name.trim() } :
+                r
+        })
+
+        tt.deepEqual(rs, [
+            "TAP version 13",
+            "do a task and write",
+            { id: 1, ok: true, name: "null" },
+            { id: 2, ok: true, name: "should be equal" },
+            { id: 3, ok: true, name: "null" },
+            "do a task and write fail",
+            { id: 4, ok: true, name: "null" },
+            { id: 5, ok: true, name: "should be equal" },
+            { id: 6, ok: false, name: "Error: fail" },
+            "tests 6",
+            "pass  5",
+            "fail  1"
+        ])
+
+        tt.end()
+    })
+
+    test.createStream().pipe(tc)
+
+    test("do a task and write", function (assert) {
+        fakeAsyncTask("foo", function (err, value) {
+            assert.ifError(err)
+            assert.equal(value, "taskfoo")
+
+            fakeAsyncWrite("bar", assert.end)
+        })
+    })
+
+    test("do a task and write fail", function (assert) {
+        fakeAsyncTask("bar", function (err, value) {
+            assert.ifError(err)
+            assert.equal(value, "taskbar")
+
+            fakeAsyncWriteFail("baz", assert.end)
+        })
+    })
+})
+
+function fakeAsyncTask(name, cb) {
+    cb(null, "task" + name)
+}
+
+function fakeAsyncWrite(name, cb) {
+    cb(null)
+}
+
+function fakeAsyncWriteFail(name, cb) {
+    cb(new Error("fail"))
+}


### PR DESCRIPTION
The use case for this is to avoid a little bit of boilerplate. 

With this patch you can pass `assert.end` as a node-style callback to your last async thing and it will do `assert.ifError(err)` for you. This is useful if you don't care about the result of the last async thing like writing to disk or db.
## before

``` js
test("configure file system for this test file", function (assert) {
    fs.writeFile(test_file, test_stuff, function (err) {
        assert.ifError(err)

        assert.end()
    })
})
```
## after

``` js
test("configure file system for this test file", function (assert) {
    fs.writeFile(test_file, test_stuff, assert.end)
})
```

My personal use-case for it is 

``` js
var test = require("tape")
var server = require("./_server")

test("ensure test server is running", function (assert) {
    server.start(assert.end)
})
```

(this is the same as #36 except I fixed the remote branch to only contain the single commit)
