### PR TITLE
Fix at printing

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -140,7 +140,11 @@ Test.prototype._assert = function assert (ok, opts) {
         
         var s = m[1].split(/\s+/);
         var filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
-        if (!filem) continue;
+        if (!filem) {
+            filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
+            
+            if (!filem) continue;
+        }
         
         if (filem[1].slice(0, dir.length) === dir) continue;
         


### PR DESCRIPTION
Some stack traces have '[as X]' in them. So now the regexp checks the s[1]
  and the s[3] which means it captures the right line (my code) instead of
  printing tape's depth

at Test.user [as _cb](/home/raynos/Documents/colingo-payments/test/integration/create-account.js:13:12)',
at Test.run (/home/raynos/Documents/colingo-payments/node_modules/tape/lib/test.js:53:14)',
