### PR TITLE
toStringified msg to prevent TypeError

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -132,7 +132,7 @@ Results.prototype.close = function () {
 function encodeResult (res, count) {
     var output = '';
     output += (res.ok ? 'ok ' : 'not ok ') + count;
-    output += res.name ? ' ' + res.name.replace(/\s+/g, ' ') : '';
+    output += res.name ? ' ' + res.name.toString().replace(/\s+/g, ' ') : '';
     
     if (res.skip) output += ' # SKIP';
     else if (res.todo) output += ' # TODO';


### PR DESCRIPTION
I discovered this when I specified a Number as the msg parameter of t.equal() call. I was just trying to debug something, but maybe there’s a use case where a non-string message is preferable?
