### PR TITLE
Reduce stack size.

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -24,14 +24,17 @@ Results.prototype.createStream = function () {
     var self = this;
     var output = resumer();
     output.queue('TAP version 13\n');
-    
-    nextTick(function () {
-        var t = getNextTest(self);
-        if (t) t.run()
-        else self.emit('done')
+
+    nextTick(function next() {
+        var t;
+        while (t = getNextTest(self)) {
+            t.run();
+            if (!t.ended) return t.once('end', function(){ nextTick(next); });
+        }
+        self.emit('done');
     });
     self._stream.pipe(output);
-    
+
     return output;
 };
 
@@ -39,11 +42,6 @@ Results.prototype.push = function (t) {
     var self = this;
     self.tests.push(t);
     self._watch(t);
-    t.once('end', function () {
-        var nt = getNextTest(self);
-        if (nt) nt.run()
-        else self.emit('done')
-    });
 };
 
 Results.prototype.only = function (name) {
@@ -69,7 +67,7 @@ Results.prototype._watch = function (t) {
         }
         write(encodeResult(res, self.count + 1));
         self.count ++;
-        
+
         if (res.ok) self.pass ++
         else self.fail ++
     });
@@ -82,13 +80,13 @@ Results.prototype.close = function () {
     if (self.closed) self._stream.emit('error', new Error('ALREADY CLOSED'));
     self.closed = true;
     var write = function (s) { self._stream.queue(s) };
-    
+
     write('\n1..' + self.count + '\n');
     write('# tests ' + self.count + '\n');
     write('# pass  ' + self.pass + '\n');
     if (self.fail) write('# fail  ' + self.fail + '\n')
     else write('\n# ok\n')
-    
+
     self._stream.queue(null);
 };
 
@@ -96,21 +94,21 @@ function encodeResult (res, count) {
     var output = '';
     output += (res.ok ? 'ok ' : 'not ok ') + count;
     output += res.name ? ' ' + res.name.toString().replace(/\s+/g, ' ') : '';
-    
+
     if (res.skip) output += ' # SKIP';
     else if (res.todo) output += ' # TODO';
-    
+
     output += '\n';
     if (res.ok) return output;
-    
+
     var outer = '  ';
     var inner = outer + '  ';
     output += outer + '---\n';
     output += inner + 'operator: ' + res.operator + '\n';
-    
+
     var ex = json.stringify(res.expected, getSerialize()) || '';
     var ac = json.stringify(res.actual, getSerialize()) || '';
-    
+
     if (Math.max(ex.length, ac.length) > 65) {
         output += inner + 'expected:\n' + inner + '  ' + ex + '\n';
         output += inner + 'actual:\n' + inner + '  ' + ac + '\n';
@@ -130,14 +128,14 @@ function encodeResult (res, count) {
             output += inner + lines[i] + '\n';
         }
     }
-    
+
     output += outer + '...\n';
     return output;
 }
 
 function getSerialize () {
     var seen = [];
-    
+
     return function (key, value) {
         var ret = value;
         if (typeof value === 'object' && value) {
@@ -148,7 +146,7 @@ function getSerialize () {
                     break;
                 }
             }
-            
+
             if (found) ret = '[Circular]'
             else seen.push(value)
         }


### PR DESCRIPTION
When running synchronous tests, each test currently increases the stack size by several frames.  When debugging the 100th test, the stack is several hundred frames deep.  This makes things difficult to debug as tools often choke on stacks of this size.

This patch runs synchronous tests in a loop instead of running each successive test in the previous test's `end` event handler.  Further, asynchronous tests resume processing on the next tick, removing the previous tests call stack before running the next one.
