### PR TITLE
windows compatibility for test/*.js (and other globs)

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
 var path = require('path');
-process.argv.slice(2).forEach(function(file) {
-    require(path.resolve(process.cwd(), file));
+var glob = require('glob');
+
+process.argv.slice(2).forEach(function(arg) {
+	glob(arg, function(er, files){
+		files.forEach(function(file){
+		    require(path.resolve(process.cwd(), file));
+		})
+	})
 });
 
 // vim: ft=javascript

--- a/package.json
+++ b/package.json
@@ -1,55 +1,57 @@
 {
-    "name" : "tape",
-    "version" : "2.4.2",
-    "description" : "tap-producing test harness for node and browsers",
-    "main" : "index.js",
-    "bin" : "./bin/tape",
-    "directories" : {
-        "example" : "example",
-        "test" : "test"
-    },
-    "dependencies" : {
-        "jsonify" : "~0.0.0",
-        "deep-equal" : "~0.2.0",
-        "defined" : "~0.0.0",
-        "through": "~2.3.4",
-        "resumer": "~0.0.0",
-        "inherits": "~2.0.1"
-    },
-    "devDependencies" : {
-        "tap" : "~0.3.0",
-        "falafel" : "~0.1.4"
-    },
-    "scripts" : {
-        "test" : "tap test/*.js"
-    },
-    "testling" : {
-        "files" : "test/browser/*.js",
-        "browsers" : [
-            "ie/6..latest",
-            "chrome/20..latest",
-            "firefox/10..latest",
-            "safari/latest",
-            "opera/11.0..latest",
-            "iphone/6", "ipad/6"
-        ]
-    },
-    "repository" : {
-        "type" : "git",
-        "url" : "git://github.com/substack/tape.git"
-    },
-    "homepage" : "https://github.com/substack/tape",
-    "keywords" : [
-        "tap",
-        "test",
-        "harness",
-        "assert",
-        "browser"
-    ],
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
-    },
-    "license" : "MIT"
+  "name": "tape",
+  "version": "2.4.2",
+  "description": "tap-producing test harness for node and browsers",
+  "main": "index.js",
+  "bin": "./bin/tape",
+  "directories": {
+    "example": "example",
+    "test": "test"
+  },
+  "dependencies": {
+    "jsonify": "~0.0.0",
+    "deep-equal": "~0.2.0",
+    "defined": "~0.0.0",
+    "through": "~2.3.4",
+    "resumer": "~0.0.0",
+    "inherits": "~2.0.1",
+    "glob": "~3.2.8"
+  },
+  "devDependencies": {
+    "tap": "~0.3.0",
+    "falafel": "~0.1.4"
+  },
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "testling": {
+    "files": "test/browser/*.js",
+    "browsers": [
+      "ie/6..latest",
+      "chrome/20..latest",
+      "firefox/10..latest",
+      "safari/latest",
+      "opera/11.0..latest",
+      "iphone/6",
+      "ipad/6"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/substack/tape.git"
+  },
+  "homepage": "https://github.com/substack/tape",
+  "keywords": [
+    "tap",
+    "test",
+    "harness",
+    "assert",
+    "browser"
+  ],
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
a la [tap](https://github.com/isaacs/node-tap/blob/master/lib/tap-runner.js#L128), glob library can be used to make tape windows compatible
