### PR TITLE
Outputs tests with no callbacks as a TODO test.

### DIFF
--- a/example/no_callback.js
+++ b/example/no_callback.js
@@ -1,0 +1,3 @@
+var test = require('../');
+
+test('No cb test');

--- a/lib/test.js
+++ b/lib/test.js
@@ -178,6 +178,9 @@ Test.prototype.end = function (err) {
 
 Test.prototype._end = function (err) {
     var self = this;
+
+    if (!this._cb && !this._todo) this.fail('# TODO ' + this.name);
+
     if (this._progeny.length) {
         var t = this._progeny.shift();
         t.on('end', function () { self._end(); });

--- a/test/no_callback.js
+++ b/test/no_callback.js
@@ -1,3 +1,35 @@
-var test = require('../');
+var tape = require('../');
+var tap = require('tap');
+var concat = require('concat-stream');
 
-test('No callback.');
+var stripFullStack = require('./common').stripFullStack;
+
+tap.test('no callback', function (tt) {
+    tt.plan(1);
+
+    var test = tape.createHarness();
+    var tc = function (rows) {
+        var body = stripFullStack(rows.toString('utf8'));
+
+        tt.same(body, [
+            'TAP version 13',
+            '# No callback.',
+            'not ok 1 # TODO No callback.',
+            '  ---',
+            '    operator: fail',
+            '    stack: |-',
+            '      Error: # TODO No callback.',
+            '          [... stack stripped ...]',
+            '  ...',
+            '',
+            '1..1',
+            '# tests 1',
+            '# pass  0',
+            '# fail  1',
+        ].join('\n') + '\n');
+    };
+
+    test.createStream().pipe(concat(tc));
+
+    test('No callback.');
+});


### PR DESCRIPTION
Patching #62, referencing any defined tests with no callback in the TAP output as a TODO test, similar to if the TODO directive described in TAP spec is used (https://metacpan.org/pod/release/PETDANCE/Test-Harness-2.64/lib/Test/Harness/TAP.pod#TODO-tests).
