### PR TITLE
Adding Test.skip

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ function createExitHarness (conf) {
 exports.createHarness = createHarness;
 exports.Test = Test;
 exports.test = exports; // tap compat
+exports.test.skip = Test.skip;
 
 var exitInterval;
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -454,4 +454,10 @@ function has (obj, prop) {
     return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
+Test.skip = function (name_, _opts, _cb) {
+    var args = getTestArgs.apply(null, arguments);
+    args.opts.skip = true;
+    return Test(args.name, args.opts, args.cb);
+};
+
 // vim: set softtabstop=4 shiftwidth=4:

--- a/readme.markdown
+++ b/readme.markdown
@@ -60,6 +60,10 @@ test object `t` once all preceeding tests have finished. Tests execute serially.
 If you forget to `t.plan()` out how many assertions you are going to run and you
 don't call `t.end()` explicitly, your test will hang.
 
+## test.skip(name, cb)
+
+Generate a new test that will be skipped over.
+
 ## t.plan(n)
 
 Declare that `n` assertions should be run. `t.end()` will be called

--- a/test/skip.js
+++ b/test/skip.js
@@ -9,6 +9,18 @@ test('do not skip this', { skip: false }, function(t) {
 
 test('skip this', { skip: true }, function(t) {
     t.fail('this should not even run');
+	ran++;
+    t.end();
+});
+
+test.skip('skip this too', function(t) {
+    t.fail('this should not even run');
+	ran++;
+    t.end();
+});
+
+test.skip('skip this too', function(t) {
+    t.fail('this should not even run');
     t.end();
 });
 


### PR DESCRIPTION
Fixes #71

I can remove the "trailing whitespace" commit if you prefer - my vim auto cleared it, and I rebased it into its own commit.

If there's any style conventions I've missed, please let me know and I'll fix them ASAP.
