### PR TITLE
do not set canEmitExit with browserify process shim

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var createResult = require('./lib/results');
 var through = require('through');
 
 var canEmitExit = typeof process !== 'undefined' && process
-    && typeof process.on === 'function'
+    && typeof process.on === 'function' && process.browser !== true
 ;
 var canExit = typeof process !== 'undefined' && process
     && typeof process.exit === 'function'


### PR DESCRIPTION
Since browserify 3.36.0 tests never finish in the browser since they added a process.on noop function.
