### PR TITLE
Exit before stdout flush on Windows

### DIFF
--- a/lib/default_stream.js
+++ b/lib/default_stream.js
@@ -1,10 +1,11 @@
 var through = require('through');
+var fs = require('fs');
 
 module.exports = function () {
     var line = '';
     var stream = through(write, flush);
     return stream;
-    
+
     function write (buf) {
         for (var i = 0; i < buf.length; i++) {
             var c = typeof buf === 'string'
@@ -15,9 +16,9 @@ module.exports = function () {
             else line += c;
         }
     }
-    
+
     function flush () {
-        try { console.log(line); }
+        try { fs.writeSync(1, line + '\n'); }
         catch (e) { stream.emit('error', e) }
         line = '';
     }


### PR DESCRIPTION
I am suffering an issue on Windows 8 where stdout isn't flushed. This is a pretty well known problem https://github.com/joyent/node/issues/3584 but it's still unclear what the best solution is. I'm using `fs.writeSync` here to make blocking writes to stdout, which seems to solve the issue, but perhaps this isn't ideal?
