### PR TITLE
Add a section about reports to the README

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -60,6 +60,7 @@ that will output something pretty if you pipe TAP into them:
  - https://github.com/calvinmetcalf/tap-nyan
  - https://www.npmjs.org/package/tap-pessimist
  - https://github.com/toolness/tap-prettify
+ - https://github.com/shuhei/colortape
 
 To use them, try `node test/index.js | tap-spec` or pipe it into one
 of the modules of your choice!


### PR DESCRIPTION
I added a section to the README documenting how many TAP based reporters we have!

I was surprised there were already 10 modules on npm including `tap-nyan` !

This should make it easier for new `tape` users to use tape even if they find raw TAP output ugly.

cc @maxogden @substack
