### PR TITLE
Globally cache tape.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ var Test = require('./lib/test');
 var createResult = require('./lib/results');
 var through = require('through');
 
+var GLOBAL = typeof window !== 'undefined' ? window :
+    typeof global !== 'undefined' ? global : {};
+
 var canEmitExit = typeof process !== 'undefined' && process
     && typeof process.on === 'function' && process.browser !== true
 ;
@@ -16,7 +19,7 @@ var nextTick = typeof setImmediate !== 'undefined'
     : process.nextTick
 ;
 
-exports = module.exports = (function () {
+exports = module.exports = GLOBAL.__TAPE_CACHED_LAZY_HARNESS || (function () {
     var harness;
     var lazyLoad = function () {
         return getHarness().apply(this, arguments);
@@ -45,6 +48,8 @@ exports = module.exports = (function () {
         return harness;
     }
 })();
+
+GLOBAL.__TAPE_CACHED_LAZY_HARNESS = module.exports;
 
 function createExitHarness (conf) {
     if (!conf) conf = {};


### PR DESCRIPTION
If you ever end up with two copies of tape this will make
  them use the same shared queue of pending tests.

This happens if you require tests from another module
  as part of your tests.

This also happens if you structure a larger app out of many
  small apps with their own node_modules.

cc @Matt-Esch
