### PR TITLE
Asynchronously declared nested tests w/ plan() w/o end()

### DIFF
--- a/test/nested-async-plan-noend.js
+++ b/test/nested-async-plan-noend.js
@@ -1,0 +1,36 @@
+var test = require('../');
+
+test('Harness async test support', function(t) {
+  t.plan(3);
+
+  t.ok(true, 'sync child A');
+
+  t.test('sync child B', function(tt) {
+    tt.plan(2);
+
+    setTimeout(function(){
+      tt.test('async grandchild A', function(ttt) {
+        ttt.plan(1);
+        ttt.ok(true);
+      });
+    }, 50);
+
+    setTimeout(function() {
+      tt.test('async grandchild B', function(ttt) {
+        ttt.plan(1);
+        ttt.ok(true);
+      });
+    }, 100);
+  });
+
+  setTimeout(function() {
+    t.test('async child', function(tt) {
+      tt.plan(2);
+      tt.ok(true, 'sync grandchild in async child A');
+      tt.test('sync grandchild in async child B', function(ttt) {
+        ttt.plan(1);
+        ttt.ok(true);
+      });
+    });
+  }, 200);
+});


### PR DESCRIPTION
Since `substack/tape` shares many of the same tests with `isaacs/node-tap` (I assume the tests here came from `node-tap`), I am adding a test from `node-tap` that I wrote to `tape`. 

Recently I added (to `node-tap`) support for asynchronously declaring nested tests to `node-tap` when you've given a plan() (the plan() lets it knows to wait for asynchronously created nested test harnesses). I added this same test to `tape` in this pull request. No further modifications were needed to `tape` since this test passed right out of the box. ... Plus it never hurts to have more tests. :)

Here is the PR on `node-tap` from where this test was pulled from: https://github.com/isaacs/node-tap/pull/103
