### PR TITLE
Do not intercept exceptions

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -69,14 +69,7 @@ Test.prototype.run = function () {
         return this._end();
     }
     this.emit('prerun');
-    try {
-        this._cb(this);
-    }
-    catch (err) {
-        this.error(err);
-        this._end();
-        return;
-    }
+    this._cb(this);
     this.emit('run');
 };
 


### PR DESCRIPTION
It's weird that tape is intercepting exceptions and will report them as TAP error.

Exceptions are actually bugs in the test code and should not output TAP failures but just crash the test program instead.

This also makes it easier to test and debug tests themself as you can just use standard tools, like any standard uncaught exception tooling or any standard debugging thrown exception tooling.
