### PR TITLE
Change "a,b" into "actual,expected"

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -127,32 +127,32 @@ description message.
 
 Aliases: `t.ifError()`, `t.ifErr()`, `t.iferror()`
 
-## t.equal(a, b, msg)
+## t.equal(actual, expected, msg)
 
-Assert that `a === b` with an optional description `msg`.
+Assert that `actual === expected` with an optional description `msg`.
 
 Aliases: `t.equals()`, `t.isEqual()`, `t.is()`, `t.strictEqual()`,
 `t.strictEquals()`
 
-## t.notEqual(a, b, msg)
+## t.notEqual(actual, expected, msg)
 
-Assert that `a !== b` with an optional description `msg`.
+Assert that `actual !== expected` with an optional description `msg`.
 
 Aliases: `t.notEquals()`, `t.notStrictEqual()`, `t.notStrictEquals()`,
 `t.isNotEqual()`, `t.isNot()`, `t.not()`, `t.doesNotEqual()`, `t.isInequal()`
 
-## t.deepEqual(a, b, msg)
+## t.deepEqual(actual, expected, msg)
 
-Assert that `a` and `b` have the same structure and nested values using
+Assert that `actual` and `bexpected` have the same structure and nested values using
 [node's deepEqual() algorithm](https://github.com/substack/node-deep-equal)
 with strict comparisons (`===`) on leaf nodes and an optional description
 `msg`.
 
 Aliases: `t.deepEquals()`, `t.isEquivalent()`, `t.same()`
 
-## t.notDeepEqual(a, b, msg)
+## t.notDeepEqual(actual, expected, msg)
 
-Assert that `a` and `b` do not have the same structure and nested values using
+Assert that `actual` and `expected` do not have the same structure and nested values using
 [node's deepEqual() algorithm](https://github.com/substack/node-deep-equal)
 with strict comparisons (`===`) on leaf nodes and an optional description
 `msg`.
@@ -161,17 +161,17 @@ Aliases: `t.notEquivalent()`, `t.notDeeply()`, `t.notSame()`,
 `t.isNotDeepEqual()`, `t.isNotDeeply()`, `t.isNotEquivalent()`,
 `t.isInequivalent()`
 
-## t.deepLooseEqual(a, b, msg)
+## t.deepLooseEqual(actual, expected, msg)
 
-Assert that `a` and `b` have the same structure and nested values using
+Assert that `actual` and `expected` have the same structure and nested values using
 [node's deepEqual() algorithm](https://github.com/substack/node-deep-equal)
 with loose comparisons (`==`) on leaf nodes and an optional description `msg`.
 
 Aliases: `t.looseEqual()`, `t.looseEquals()`
 
-## t.notDeepLooseEqual(a, b, msg)
+## t.notDeepLooseEqual(actual, expected, msg)
 
-Assert that `a` and `b` do not have the same structure and nested values using
+Assert that `actual` and `expected` do not have the same structure and nested values using
 [node's deepEqual() algorithm](https://github.com/substack/node-deep-equal)
 with loose comparisons (`==`) on leaf nodes and an optional description `msg`.
 


### PR DESCRIPTION
I thought it would be nice that the paramenter names matched the output where the words used are "actual" and "expected".
