### PR TITLE
notLooseEquals should be !deepEqual

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -385,7 +385,7 @@ Test.prototype.notDeepLooseEqual
 = Test.prototype.notLooseEqual
 = Test.prototype.notLooseEquals
 = function (a, b, msg, extra) {
-    this._assert(deepEqual(a, b), {
+    this._assert(!deepEqual(a, b), {
         message : defined(msg, 'should be equivalent'),
         operator : 'notDeepLooseEqual',
         actual : a,


### PR DESCRIPTION
This fixes a bug where the notLooseEquals assertion was actually `looseEquals`

It was missing a negation!

cc @substack
