### PR TITLE
Make `tape` behave more like node `assert`.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -112,7 +112,7 @@ Test.prototype.end = function (err) {
     }
     
     if (this.calledEnd) {
-        this.fail('.end() called twice');
+        this.fail(null, null, '.end() called twice');
     }
     this.calledEnd = true;
     this._end();
@@ -131,7 +131,7 @@ Test.prototype._end = function (err) {
     var pendingAsserts = this._pendingAsserts();
     if (!this._planError && this._plan !== undefined && pendingAsserts) {
         this._planError = true;
-        this.fail('plan != count', {
+        this.fail(this.assertCount, this._plan, 'plan != count', 'fail', {
             expected : this._plan,
             actual : this.assertCount
         });
@@ -143,14 +143,14 @@ Test.prototype._exit = function () {
     if (this._plan !== undefined &&
         !this._planError && this.assertCount !== this._plan) {
         this._planError = true;
-        this.fail('plan != count', {
+        this.fail(this.assertCount, this._plan, 'plan != count', 'fail', {
             expected : this._plan,
             actual : this.assertCount,
             exiting : true
         });
     }
     else if (!this.ended) {
-        this.fail('test exited without ending', {
+        this.fail(null, null, 'test exited without ending', 'fail', {
             exiting: true
         });
     }
@@ -230,10 +230,11 @@ Test.prototype._assert = function assert (ok, opts) {
     
     if (!self._planError && pendingAsserts < 0) {
         self._planError = true;
-        self.fail('plan != count', {
-            expected : self._plan,
-            actual : self._plan - pendingAsserts
-        });
+        self.fail(self._plan - pendingAsserts, self._plan,
+            'plan != count', 'fail', {
+                expected : self._plan,
+                actual : self._plan - pendingAsserts
+            });
     }
 };
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -237,10 +237,12 @@ Test.prototype._assert = function assert (ok, opts) {
     }
 };
 
-Test.prototype.fail = function (msg, extra) {
+Test.prototype.fail = function (actual, expected, msg, operator, extra) {
     this._assert(false, {
         message : msg,
-        operator : 'fail',
+        actual: actual,
+        expected: expected,
+        operator : operator || 'fail',
         extra : extra
     });
 };

--- a/lib/test.js
+++ b/lib/test.js
@@ -245,14 +245,6 @@ Test.prototype.fail = function (msg, extra) {
     });
 };
 
-Test.prototype.pass = function (msg, extra) {
-    this._assert(true, {
-        message : msg,
-        operator : 'pass',
-        extra : extra
-    });
-};
-
 Test.prototype.skip = function (msg, extra) {
     this._assert(true, {
         message : msg,
@@ -262,10 +254,7 @@ Test.prototype.skip = function (msg, extra) {
     });
 };
 
-Test.prototype.ok
-= Test.prototype['true']
-= Test.prototype.assert
-= function (value, msg, extra) {
+Test.prototype.ok = function (value, msg, extra) {
     this._assert(value, {
         message : msg,
         operator : 'ok',
@@ -275,24 +264,7 @@ Test.prototype.ok
     });
 };
 
-Test.prototype.notOk
-= Test.prototype['false']
-= Test.prototype.notok
-= function (value, msg, extra) {
-    this._assert(!value, {
-        message : msg,
-        operator : 'notOk',
-        expected : false,
-        actual : value,
-        extra : extra
-    });
-};
-
-Test.prototype.error
-= Test.prototype.ifError
-= Test.prototype.ifErr
-= Test.prototype.iferror
-= function (err, msg, extra) {
+Test.prototype.ifError = function (err, msg, extra) {
     this._assert(!err, {
         message : defined(msg, String(err)),
         operator : 'error',
@@ -301,13 +273,7 @@ Test.prototype.error
     });
 };
 
-Test.prototype.equal
-= Test.prototype.equals
-= Test.prototype.isEqual
-= Test.prototype.is
-= Test.prototype.strictEqual
-= Test.prototype.strictEquals
-= function (a, b, msg, extra) {
+Test.prototype.equal = function (a, b, msg, extra) {
     this._assert(a === b, {
         message : defined(msg, 'should be equal'),
         operator : 'equal',
@@ -316,17 +282,9 @@ Test.prototype.equal
         extra : extra
     });
 };
+Test.prototype.strictEqual = Test.prototype.equal;
 
-Test.prototype.notEqual
-= Test.prototype.notEquals
-= Test.prototype.notStrictEqual
-= Test.prototype.notStrictEquals
-= Test.prototype.isNotEqual
-= Test.prototype.isNot
-= Test.prototype.not
-= Test.prototype.doesNotEqual
-= Test.prototype.isInequal
-= function (a, b, msg, extra) {
+Test.prototype.notEqual = function (a, b, msg, extra) {
     this._assert(a !== b, {
         message : defined(msg, 'should not be equal'),
         operator : 'notEqual',
@@ -335,12 +293,9 @@ Test.prototype.notEqual
         extra : extra
     });
 };
+Test.prototype.notStrictEqual = Test.prototype.notEqual;
 
-Test.prototype.deepEqual
-= Test.prototype.deepEquals
-= Test.prototype.isEquivalent
-= Test.prototype.same
-= function (a, b, msg, extra) {
+Test.prototype.deepEqual = function (a, b, msg, extra) {
     this._assert(deepEqual(a, b, { strict: true }), {
         message : defined(msg, 'should be equivalent'),
         operator : 'deepEqual',
@@ -350,46 +305,12 @@ Test.prototype.deepEqual
     });
 };
 
-Test.prototype.deepLooseEqual
-= Test.prototype.looseEqual
-= Test.prototype.looseEquals
-= function (a, b, msg, extra) {
-    this._assert(deepEqual(a, b), {
-        message : defined(msg, 'should be equivalent'),
-        operator : 'deepLooseEqual',
-        actual : a,
-        expected : b,
-        extra : extra
-    });
-};
-
-Test.prototype.notDeepEqual
-= Test.prototype.notEquivalent
-= Test.prototype.notDeeply
-= Test.prototype.notSame
-= Test.prototype.isNotDeepEqual
-= Test.prototype.isNotDeeply
-= Test.prototype.isNotEquivalent
-= Test.prototype.isInequivalent
-= function (a, b, msg, extra) {
+Test.prototype.notDeepEqual = function (a, b, msg, extra) {
     this._assert(!deepEqual(a, b, { strict: true }), {
         message : defined(msg, 'should not be equivalent'),
         operator : 'notDeepEqual',
         actual : a,
         notExpected : b,
-        extra : extra
-    });
-};
-
-Test.prototype.notDeepLooseEqual
-= Test.prototype.notLooseEqual
-= Test.prototype.notLooseEquals
-= function (a, b, msg, extra) {
-    this._assert(!deepEqual(a, b), {
-        message : defined(msg, 'should be equivalent'),
-        operator : 'notDeepLooseEqual',
-        actual : a,
-        expected : b,
         extra : extra
     });
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -82,6 +82,9 @@ test object `t` once all preceeding tests have finished. Tests execute serially.
 If you forget to `t.plan()` out how many assertions you are going to run and you
 don't call `t.end()` explicitly, your test will hang.
 
+Note the `cb` is optional, if the `cb` is not specified then
+  the test will be skipped.
+
 ## test.skip(name, cb)
 
 Generate a new test that will be skipped over.
@@ -96,50 +99,34 @@ the `n`th, or after `t.end()` is called, they will generate errors.
 
 Declare the end of a test explicitly.
 
-## t.fail(msg)
-
-Generate a failing assertion with a message `msg`.
-
-## t.pass(msg)
-
-Generate a passing assertion with a message `msg`.
-
 ## t.skip(msg)
  
 Generate an assertion that will be skipped over.
+
+## t.fail(msg)
+
+Generate a failing assertion with a message `msg`.
 
 ## t.ok(value, msg)
 
 Assert that `value` is truthy with an optional description message `msg`.
 
-Aliases: `t.true()`, `t.assert()`
-
-## t.notOk(value, msg)
-
-Assert that `value` is falsy with an optional description message `msg`.
-
-Aliases: `t.false()`, `t.notok()`
-
-## t.error(err, msg)
+## t.ifError(err, msg)
 
 Assert that `err` is falsy. If `err` is non-falsy, use its `err.message` as the
 description message.
-
-Aliases: `t.ifError()`, `t.ifErr()`, `t.iferror()`
 
 ## t.equal(actual, expected, msg)
 
 Assert that `actual === expected` with an optional description `msg`.
 
-Aliases: `t.equals()`, `t.isEqual()`, `t.is()`, `t.strictEqual()`,
-`t.strictEquals()`
+Aliases: `t.strictEqual()`
 
 ## t.notEqual(actual, expected, msg)
 
 Assert that `actual !== expected` with an optional description `msg`.
 
-Aliases: `t.notEquals()`, `t.notStrictEqual()`, `t.notStrictEquals()`,
-`t.isNotEqual()`, `t.isNot()`, `t.not()`, `t.doesNotEqual()`, `t.isInequal()`
+Aliases: `t.notStrictEqual()`
 
 ## t.deepEqual(actual, expected, msg)
 
@@ -160,22 +147,6 @@ with strict comparisons (`===`) on leaf nodes and an optional description
 Aliases: `t.notEquivalent()`, `t.notDeeply()`, `t.notSame()`,
 `t.isNotDeepEqual()`, `t.isNotDeeply()`, `t.isNotEquivalent()`,
 `t.isInequivalent()`
-
-## t.deepLooseEqual(actual, expected, msg)
-
-Assert that `actual` and `expected` have the same structure and nested values using
-[node's deepEqual() algorithm](https://github.com/substack/node-deep-equal)
-with loose comparisons (`==`) on leaf nodes and an optional description `msg`.
-
-Aliases: `t.looseEqual()`, `t.looseEquals()`
-
-## t.notDeepLooseEqual(actual, expected, msg)
-
-Assert that `actual` and `expected` do not have the same structure and nested values using
-[node's deepEqual() algorithm](https://github.com/substack/node-deep-equal)
-with loose comparisons (`==`) on leaf nodes and an optional description `msg`.
-
-Aliases: `t.notLooseEqual()`, `t.notLooseEquals()`
 
 ## t.throws(fn, expected, msg)
 

--- a/test/nested.js
+++ b/test/nested.js
@@ -17,7 +17,7 @@ tap.test('array test', function (tt) {
             }
             else return r;
         });
-        tt.same(rs, [
+        tt.deepEqual(rs, [
             'TAP version 13',
             'nested array test',
             { id: 1, ok: true, name: 'should be equivalent' },
@@ -71,11 +71,11 @@ tap.test('array test', function (tt) {
         
         Function(['fn','g'], output)(
             function (xs) {
-                t.same(arrays.shift(), xs);
+                t.deepEqual(arrays.shift(), xs);
                 return xs;
             },
             function (xs) {
-                t.same(xs, [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ]);
+                t.deepEqual(xs, [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ]);
             }
         );
     });

--- a/test/plan_optional.js
+++ b/test/plan_optional.js
@@ -1,13 +1,13 @@
 var test = require('../');
 
 test('plan should be optional', function (t) {
-    t.pass('no plan here');
+    t.ok(true, 'no plan here');
     t.end();
 });
 
 test('no plan async', function (t) {
     setTimeout(function() {
-        t.pass('ok');
+        t.ok(true, 'ok');
         t.end();
     }, 100);
 });

--- a/test/skip.js
+++ b/test/skip.js
@@ -2,7 +2,7 @@ var test = require('../');
 var ran = 0;
 
 test('do not skip this', { skip: false }, function(t) {
-    t.pass('this should run');
+    t.ok(true, 'this should run');
     ran ++;
     t.end();
 });
@@ -28,7 +28,7 @@ test('skip subtest', function(t) {
     ran ++;
     t.test('do not skip this', { skip: false }, function(t) {
         ran ++;
-        t.pass('this should run');
+        t.ok(true, 'this should run');
         t.end();
     });
     t.test('skip this', { skip: true }, function(t) {

--- a/test/subcount.js
+++ b/test/subcount.js
@@ -4,11 +4,11 @@ test('parent test', function (t) {
     t.plan(2);
     t.test('first child', function (t) {
         t.plan(1);
-        t.pass('pass first child');
+        t.ok(true, 'pass first child');
     })
 
     t.test(function (t) {
         t.plan(1);
-        t.pass('pass second child');
+        t.ok(true, 'pass second child');
     })
 })

--- a/test/subtest_and_async.js
+++ b/test/subtest_and_async.js
@@ -6,17 +6,17 @@ var asyncFunction = function (callback) {
 
 test('master test', function (t) {
   t.test('subtest 1', function (t) {
-    t.pass('subtest 1 before async call');
+    t.ok(true, 'subtest 1 before async call');
     asyncFunction(function () {
-      t.pass('subtest 1 in async callback');
+      t.ok(true, 'subtest 1 in async callback');
       t.end();
     })
   });
 
   t.test('subtest 2', function (t) {
-    t.pass('subtest 2 before async call');
+    t.ok(true, 'subtest 2 before async call');
     asyncFunction(function () {
-      t.pass('subtest 2 in async callback');
+      t.ok(true, 'subtest 2 in async callback');
       t.end();
     })
   });

--- a/test/subtest_plan.js
+++ b/test/subtest_plan.js
@@ -5,17 +5,17 @@ test('parent', function (t) {
 
     var firstChildRan = false;
 
-    t.pass('assertion in parent');
+    t.ok(true, 'assertion in parent');
 
     t.test('first child', function (t) {
         t.plan(1);
-        t.pass('pass first child');
+        t.ok(true, 'pass first child');
         firstChildRan = true;
     });
 
     t.test('second child', function (t) {
         t.plan(2);
         t.ok(firstChildRan, 'first child ran first');
-        t.pass('pass second child');
+        t.ok(true, 'pass second child');
     });
 });

--- a/test/too_many.js
+++ b/test/too_many.js
@@ -58,11 +58,11 @@ tap.test('array test', function (tt) {
         
         Function(['fn','g'], output)(
             function (xs) {
-                t.same(arrays.shift(), xs);
+                t.deepEqual(arrays.shift(), xs);
                 return xs;
             },
             function (xs) {
-                t.same(xs, [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ]);
+                t.deepEqual(xs, [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ]);
             }
         );
     });


### PR DESCRIPTION
This removes excess methods on the `Test` prototype.

There are a bunch of methods and aliases on the `Test` prototype
   that are not defined on assert for node core.

This adds a bunch of undocumented complexity and unnecessary
   deviation in the way that `tape` is used.

I'd be nice to remove these aliases and make `tape` a drop in
   replacement for `assert`.

This means that tape tests are more consistent and it means 
    it's easier to find the documentation by just reading the
    the node assert documentation.

This is a breaking change. Recommended version **major**.

cc @substack.
