### PR TITLE
Remove uncaught-exception listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,8 +64,20 @@ function createExitHarness (conf) {
     if (conf.exit === false) return harness;
     if (!canEmitExit || !canExit) return harness;
 
+    var inErrorState = false;
+
+    var $_fatalException = process._fatalException
+    process._fatalException = function fakeFatalException() {
+        inErrorState = true;
+        $_fatalException.apply(this, arguments)
+    }
 
     process.on('exit', function (code) {
+        // let the process exit cleanly.
+        if (inErrorState) {
+            return
+        }
+
         if (!ended) {
             var only = harness._results._only;
             for (var i = 0; i < harness._tests.length; i++) {

--- a/index.js
+++ b/index.js
@@ -63,23 +63,9 @@ function createExitHarness (conf) {
     
     if (conf.exit === false) return harness;
     if (!canEmitExit || !canExit) return harness;
-    
-    var _error;
 
-    process.on('uncaughtException', function (err) {
-        if (err && err.code === 'EPIPE' && err.errno === 'EPIPE'
-        && err.syscall === 'write') return;
-        
-        _error = err
-        
-        throw err
-    })
 
     process.on('exit', function (code) {
-        if (_error) {
-            return
-        }
-
         if (!ended) {
             var only = harness._results._only;
             for (var i = 0; i < harness._tests.length; i++) {


### PR DESCRIPTION
A testing library should not have an uncaught-exception listener, it makes testing hard code like uncaught exceptions harder.

For example
`
```
$ node endpoints/user/test/
TAP version 13
# can register

/home/raynos/projects/manga-feed/node_modules/tape/index.js:75
        throw err
              ^
RangeError: Maximum call stack size exceeded
```

Tape intercepts my range error and ruins the stack by rethrowing.

The particular PIPE bug we were gaurding against is better dealt with by adding 
an error listener on `process.stdout` or something.

Not really sure which EPIPE we are gaurding against. I recommend removing it
for now and we can add it back later.
