### PR TITLE
Add a Function.constructor check to throws.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -18,7 +18,7 @@ var getTestArgs = function (name_, opts_, cb_) {
     var name = '(anonymous)';
     var opts = {};
     var cb;
-    
+
     for (var i = 0; i < arguments.length; i++) {
         var arg = arguments[i];
         var t = typeof arg;
@@ -399,11 +399,12 @@ Test.prototype['throws'] = function (fn, expected, msg, extra) {
         msg = expected;
         expected = undefined;
     }
+
     var caught = undefined;
+
     try {
         fn();
-    }
-    catch (err) {
+    } catch (err) {
         caught = { error : err };
         var message = err.message;
         delete err.message;
@@ -415,6 +416,11 @@ Test.prototype['throws'] = function (fn, expected, msg, extra) {
     if (expected instanceof RegExp) {
         passed = expected.test(caught && caught.error);
         expected = String(expected);
+    }
+
+    if (typeof expected === 'function') {
+        passed = caught.error instanceof expected;
+        caught.error = caught.error.constructor;
     }
 
     this._assert(passed, {

--- a/readme.markdown
+++ b/readme.markdown
@@ -180,7 +180,7 @@ Aliases: `t.notLooseEqual()`, `t.notLooseEquals()`
 
 ## t.throws(fn, expected, msg)
 
-Assert that the function call `fn()` throws an exception. `expected`, if present, must be a `RegExp`.
+Assert that the function call `fn()` throws an exception. `expected`, if present, must be a `RegExp` or `Function`.
 
 ## t.doesNotThrow(fn, expected, msg)
 

--- a/test/throws.js
+++ b/test/throws.js
@@ -1,0 +1,20 @@
+var test = require('../');
+
+function fn() {
+    throw new TypeError('RegExp');
+}
+
+test('throws', function (t) {
+    t.throws(fn);
+    t.end();
+});
+
+test('throws (RegExp match)', function (t) {
+    t.throws(fn, /RegExp/);
+    t.end();
+});
+
+test('throws (Function match)', function (t) {
+    t.throws(fn, TypeError);
+    t.end();
+});


### PR DESCRIPTION
Allows you to also write:

```
t.throws(fn, TypeError);
```

