### PR TITLE
Improve at error detection

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -188,33 +188,45 @@ Test.prototype._assert = function assert (ok, opts) {
         res.error = defined(extra.error, opts.error, new Error(res.name));
     }
     
-    var e = new Error('exception');
-    var err = (e.stack || '').split('\n');
-    var dir = path.dirname(__dirname) + '/';
-    
-    for (var i = 0; i < err.length; i++) {
-        var m = /^\s*\bat\s+(.+)/.exec(err[i]);
-        if (!m) continue;
+    if (!ok) {
+        var e = new Error('exception');
+        var err = (e.stack || '').split('\n');
+        var dir = path.dirname(__dirname) + '/';
         
-        var s = m[1].split(/\s+/);
-        var filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
-        if (!filem) {
-            filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
+        for (var i = 0; i < err.length; i++) {
+            var m = /^[^\s]*\s*\bat\s+(.+)/.exec(err[i]);
+            if (!m) {
+                continue;
+            }
             
-            if (!filem) continue;
+            var s = m[1].split(/\s+/);
+            var filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
+            if (!filem) {
+                filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[2]);
+                
+                if (!filem) {
+                    filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
+
+                    if (!filem) {
+                        continue;
+                    }
+                }
+            }
+            
+            if (filem[1].slice(0, dir.length) === dir) {
+                continue;
+            }
+            
+            res.functionName = s[0];
+            res.file = filem[1];
+            res.line = Number(filem[2]);
+            if (filem[3]) res.column = filem[3];
+            
+            res.at = m[1];
+            break;
         }
-        
-        if (filem[1].slice(0, dir.length) === dir) continue;
-        
-        res.functionName = s[0];
-        res.file = filem[1];
-        res.line = Number(filem[2]);
-        if (filem[3]) res.column = filem[3];
-        
-        res.at = m[1];
-        break;
     }
-    
+
     self.emit('result', res);
     
     var pendingAsserts = self._pendingAsserts();
@@ -460,3 +472,4 @@ Test.skip = function (name_, _opts, _cb) {
 };
 
 // vim: set softtabstop=4 shiftwidth=4:
+


### PR DESCRIPTION
- Improve performance by only computing stack if its not ok.
- Fix bug where stack pretty printers prepend stuff to the
   stack. i.e. we now allows ^[^\s]*\s* instead of ^\s*
- Fix edgecase stack line is `[Object object].method`.
   We now test s[1], s[2] and s[3] to work around this.

This improves the detection of `at` and makes it more likely
   to be correct.

This is a very important feature as it's the only thing that
   makes debugging failed assertions easy.

Not fixing this causes some assertions to just not print an
   `at` statement at all.

cc @substack