### PR TITLE
Subtests output indentation.

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -92,15 +92,15 @@ Results.prototype._watch = function (t) {
     var self = this;
     var write = function (s) { self._stream.queue(s) };
     t.once('prerun', function () {
-        write('# ' + t.name + '\n');
+        write('# ' + getIndentation(t._level) + t.name + '\n');
     });
     
     t.on('result', function (res) {
         if (typeof res === 'string') {
-            write('# ' + res + '\n');
+            write('# ' + getIndentation(t._level) + res + '\n');
             return;
         }
-        write(encodeResult(res, self.count + 1));
+        write(getIndentation(t._level) + encodeResult(res, self.count + 1));
         self.count ++;
 
         if (res.ok) self.pass ++
@@ -124,6 +124,12 @@ Results.prototype.close = function () {
 
     self._stream.queue(null);
 };
+
+function getIndentation(level) {
+  var indent = '';
+  while (level-- > 0) indent += '    ';
+  return indent;
+}
 
 function encodeResult (res, count) {
     var output = '';

--- a/lib/test.js
+++ b/lib/test.js
@@ -46,6 +46,7 @@ function Test (name_, opts_, cb_) {
     this.assertCount = 0;
     this.pendingCount = 0;
     this._skip = args.opts.skip || false;
+    this._level = args.opts.level || 0;
     this._plan = undefined;
     this._cb = args.cb;
     this._progeny = [];
@@ -79,6 +80,7 @@ Test.prototype.run = function () {
 Test.prototype.test = function (name, opts, cb) {
     var self = this;
     var t = new Test(name, opts, cb);
+    t._level = this._level + 1;
     this._progeny.push(t);
     this.pendingCount++;
     this.emit('test', t);

--- a/test/output-indentation.js
+++ b/test/output-indentation.js
@@ -1,0 +1,30 @@
+var test = require('../');
+
+test('Output indentation', function(t) {
+  // Make some 3 level output.
+  t.comment('LEVEL0');
+  t.ok(true, 'LEVEL0');
+  t.test('sync child B', function(tt) {
+    tt.comment('LEVEL1');
+    tt.ok(true, 'LEVEL1');
+    setTimeout(function(){
+      tt.test('async grandchild A', function(ttt) {
+        ttt.comment('LEVEL2');
+        ttt.ok(true, 'LEVEL2');
+        ttt.end();
+        tt.end();
+        t.end();
+      });
+    }, 50);
+  });
+
+  // Do not do any testing while tests are still starting. t.ok() should happen afterwards.
+  var tc = test.createStream(), rows = [];
+  tc.on('data', function (r) {
+    rows.push(r);
+    if (r.indexOf('..') > 0) { // Test only after testing summary is printed.
+      t.ok(rows.some(function (r) { return r === '#     sync child B\n'; }), 'level 1 indentation ok');
+      t.ok(rows.some(function (r) { return r === '#         async grandchild A\n'; }), 'level 1 indentation ok');
+    }
+  });
+});


### PR DESCRIPTION
Implements #129. The output would look like this. Not so pretty IMO.
```
TAP version 13
# Test name
# LEVEL0
ok 1 LEVEL0
#     Sub-test name
#     LEVEL1
    ok 2 LEVEL1
#         Sub-sub-test name
#         LEVEL2
        ok 3 LEVEL2
```