### PR TITLE
Detect `inErrorState` with code not equal to zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,15 +66,9 @@ function createExitHarness (conf) {
 
     var inErrorState = false;
 
-    var $_fatalException = process._fatalException
-    process._fatalException = function fakeFatalException() {
-        inErrorState = true;
-        $_fatalException.apply(this, arguments)
-    }
-
     process.on('exit', function (code) {
         // let the process exit cleanly.
-        if (inErrorState) {
+        if (code !== 0) {
             return
         }
 


### PR DESCRIPTION
Currently the following code will fail:

```js
var test = require('tape');
var net = require('net');

test('some nextTick code', function t(assert) {
  net.createConnection({ host: 'localhost', port: 9999 }) // dead port

  process.once('uncaughtException', function (e) {
    assert.ok(e);
    assert.end();
  });
});
```

Tape uncaught exception detection logic is not clever enough, it will print the uncaught exception stack instead of exiting zero.

I've changed the detection to switch on the exit code in the event instead.

This matches the different levels in node

 - https://github.com/joyent/node/blob/v0.10.32-release/src/node.js#L222
 - https://github.com/joyent/node/blob/v0.10.32-release/src/node.js#L276-L282

The most important thing is that we only want to exit in `inErrorState` if that `caught` boolean in node core is false.

reviewers: @sh1mmer

cc @substack 