### PR TITLE
Only check for errors in callback if exist

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -122,7 +122,7 @@ Test.prototype.timeoutAfter = function(ms) {
 
 Test.prototype.end = function (err) { 
     var self = this;
-    if (arguments.length >= 1) {
+    if (arguments.length >= 1 && !!err) {
         this.ifError(err);
     }
     

--- a/test/end-as-callback.js
+++ b/test/end-as-callback.js
@@ -19,13 +19,12 @@ tap.test("tape assert.end as callback", function (tt) {
             "do a task and write",
             { id: 1, ok: true, name: "null" },
             { id: 2, ok: true, name: "should be equal" },
-            { id: 3, ok: true, name: "null" },
             "do a task and write fail",
-            { id: 4, ok: true, name: "null" },
-            { id: 5, ok: true, name: "should be equal" },
-            { id: 6, ok: false, name: "Error: fail" },
-            "tests 6",
-            "pass  5",
+            { id: 3, ok: true, name: "null" },
+            { id: 4, ok: true, name: "should be equal" },
+            { id: 5, ok: false, name: "Error: fail" },
+            "tests 5",
+            "pass  4",
             "fail  1"
         ])
 


### PR DESCRIPTION
This removes an unnecessary assert null in
case you do `thing.close(assert.end)` and
the `close()` operation does not have an
error.

This keeps the TAP output cleaner.

reviewers: @jcorbin @malandrew 

cc: @substack