### PR TITLE
Clarify comment documentation

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -217,6 +217,10 @@ Create a subtest with a new test handle `st` from `cb(st)` inside the current
 test `t`. `cb(st)` will only fire when `t` finishes. Additional tests queued up
 after `t` will not be run until all subtests finish.
 
+## t.comment(message)
+
+Print a message without breaking the tap output. (Useful when using e.g. `tap-colorize` where output is buffered & `console.log` will print in incorrect order vis-a-vis tap output.)
+
 ## var htest = test.createHarness()
 
 Create a new test harness instance, which is a function like `test()`, but with
@@ -225,11 +229,6 @@ a new pending stack and test state.
 By default the TAP output goes to `console.log()`. You can pipe the output to
 someplace else if you `htest.createStream().pipe()` to a destination stream on
 the first tick.
-
-
-## test.comment(message)
-
-Print a message without breaking the tap output. (Useful when using e.g. `tap-colorize` where output is buffered & `console.log` will print in incorrect order vis-a-vis tap output.)
 
 ## test.only(name, cb)
 


### PR DESCRIPTION
I'm getting that `test.comment()` is undefined; so I'm thinking that `t.comment()` is what was intended to be documented. Right?

I moved it only so that it is next to the other `t` methods.