### PR TITLE
Update `object-inspect`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "defined": "~0.0.0",
     "glob": "~5.0.3",
     "inherits": "~2.0.1",
-    "object-inspect": "~1.0.0",
+    "object-inspect": "~1.0.1",
     "resumer": "~0.0.0",
     "through": "~2.3.4"
   },


### PR DESCRIPTION
This fixes #158 by ensuring that a minimum of v1.0.1 of `object-inspect` is used.