### PR TITLE
Adding --init option to tape cli

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -2,6 +2,13 @@
 
 var path = require('path');
 var glob = require('glob');
+var init = require('tape-init');
+var hasFlag = require('has-flag');
+
+if (hasFlag('init')) {
+  init();
+  return;
+}
 
 process.argv.slice(2).forEach(function (arg) {
     glob(arg, function (err, files) {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "deep-equal": "~1.0.0",
     "defined": "~0.0.0",
     "glob": "~5.0.3",
+    "has-flag": "^1.0.0",
     "inherits": "~2.0.1",
     "object-inspect": "~1.0.0",
     "resumer": "~0.0.0",
+    "tape-init": "^1.0.0",
     "through": "~2.3.4"
   },
   "devDependencies": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -64,6 +64,16 @@ $ tape 'tests/**/*.js'
 $ tape "tests/**/*.js"
 ```
 
+## add tape to your project
+
+You can add `tape` to your project by running:
+
+```sh
+$ tape --init
+```
+
+Which will install and save `tape` to your current project and setup `scripts.test` to run tape. See [`tape-init`](https://www.npmjs.com/package/tape-init) for more info.
+
 # things that go well with tape
 
 tape maintains a fairly minimal core. Additional features are usually added by using another module alongside tape.


### PR DESCRIPTION
With this change one can run:

```sh
$ tape --init
```

To add `tape` to the current project, including a npm test script.

What do you think?