### PR TITLE
Fix parsing of stack traces on windows

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -207,7 +207,7 @@ Test.prototype._assert = function assert (ok, opts) {
     if (!ok) {
         var e = new Error('exception');
         var err = (e.stack || '').split('\n');
-        var dir = path.dirname(__dirname) + '/';
+        var dir = path.dirname(__dirname) + path.sep;
         
         for (var i = 0; i < err.length; i++) {
             var m = /^[^\s]*\s*\bat\s+(.+)/.exec(err[i]);
@@ -216,12 +216,12 @@ Test.prototype._assert = function assert (ok, opts) {
             }
             
             var s = m[1].split(/\s+/);
-            var filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
+            var filem = /((?:\/|\w:\\)[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
             if (!filem) {
-                filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[2]);
+                filem = /((?:\/|\w:\\)[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[2]);
                 
                 if (!filem) {
-                    filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
+                    filem = /((?:\/|\w:\\)[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
 
                     if (!filem) {
                         continue;


### PR DESCRIPTION
`functionName`, `file`, `line`, `column` will now be properly set in result objects (and subsequently tape text output).

I wanted to add a test case, however having to workaround `__dirname` is probably not worth the effort (and would make the test case itself change behaviour based on the host OS too) 