### PR TITLE
Report skipped assertions

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -21,6 +21,7 @@ function Results () {
     this.count = 0;
     this.fail = 0;
     this.pass = 0;
+    this.skip = 0;
     this._stream = through();
     this.tests = [];
     this._only = null;
@@ -103,7 +104,8 @@ Results.prototype._watch = function (t) {
         write(encodeResult(res, self.count + 1));
         self.count ++;
 
-        if (res.ok) self.pass ++
+        if (res.skip) self.skip ++
+        else if (res.ok) self.pass ++
         else {
             self.fail ++;
             self.emit('fail');
@@ -121,6 +123,7 @@ Results.prototype.close = function () {
 
     write('\n1..' + self.count + '\n');
     write('# tests ' + self.count + '\n');
+    if (self.skip) write('# skip ' + self.skip + '\n');
     write('# pass  ' + self.pass + '\n');
     if (self.fail) write('# fail  ' + self.fail + '\n')
     else write('\n# ok\n')
@@ -131,11 +134,11 @@ Results.prototype.close = function () {
 function encodeResult (res, count) {
     var output = '';
     output += (res.ok ? 'ok ' : 'not ok ') + count;
-    output += res.name ? ' ' + res.name.toString().replace(/\s+/g, ' ') : '';
 
     if (res.skip) output += ' # SKIP';
     else if (res.todo) output += ' # TODO';
 
+    output += res.name ? ' ' + res.name.toString().replace(/\s+/g, ' ') : '';
     output += '\n';
     if (res.ok) return output;
 

--- a/test/skip-output.js
+++ b/test/skip-output.js
@@ -1,0 +1,54 @@
+var tape = require('../');
+var tap = require('tap');
+var concat = require('concat-stream');
+
+tap.test('skip output test', function (tt) {
+    tt.plan(1);
+
+    var test = tape.createHarness({ exit : false });
+    test.createStream().pipe(concat(function (body) {
+        tt.equal(
+            body.toString('utf8'),
+            'TAP version 13\n'
+            + '# skip assertions\n'
+            + 'ok 1 # SKIP not enough pylons\n'
+            + '# skip subtests\n'
+            + '\n'
+            + '1..1\n'
+            + '# tests 1\n'
+            + '# skip 1\n'
+            + '# pass  0\n'
+            + '\n'
+            + '# ok\n'
+        );
+    }));
+
+    // doesn't look like test.skip is available with createHarness()
+    // test.skip('we require more minerals', function (t) {
+    //     t.plan(1);
+    //     t.fail('should not fail test.skip()');
+    // });
+
+    test('we require more vespene gas', { skip: true }, function (t) {
+        t.plan(1);
+        t.fail('should not fail test with { skip: true}');
+    });
+
+    test('skip assertions', function (t) {
+        t.plan(1);
+        t.skip('not enough pylons');
+    });
+
+    test('skip subtests', function (t) {
+        // doesn't look like test.skip is available with createHarness()
+        // test.skip('build more farms', function (t) {
+        //     t.plan(1)
+        //     t.fail('should not run subtest with test.skip()');
+        // });
+        test('we require more ziggurats', { skip: true }, function (t) {
+            t.plan(1)
+            t.fail('should not run subtest with { skip: true }');
+        });
+        t.end();
+    });
+});

--- a/test/skip.js
+++ b/test/skip.js
@@ -28,17 +28,32 @@ tap.test('test SKIP comment', function (assert) {
     });
 });
 
+test('does not skip with { skip: false }', function(t) {
+    t.equal(ran, 1, 'should have run the previous test');
+    t.end();
+})
+
 test('skip this', { skip: true }, function(t) {
     t.fail('this should not even run');
     ran++;
     t.end();
 });
 
+test('does skip with { skip: true }', function(t) {
+    t.equal(ran, 1, 'should not have run the previous test');
+    t.end();
+})
+
 test.skip('skip this too', function(t) {
     t.fail('this should not even run');
     ran++;
     t.end();
 });
+
+test('does skip with test.skip', function(t) {
+    t.equal(ran, 1, 'should not have run the previous test');
+    t.end();
+})
 
 test('skip subtest', function(t) {
     ran++;


### PR DESCRIPTION
This should address some of #90
- [x] show skipped assertions like in the spec, e.g. `ok 23 # skip Insufficient flogiston pressure.`
- [ ] show skipped tests like in the spec, e.g. `1..0 # Skipped: WWW::Mechanize not installed`
- [x] include the count of skipped tests in the generated output, like the spec says:

I should be able to look at the last bit in the next week or two.
