### PR TITLE
update dependencies and tests (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "through": "~2.3.4"
   },
   "devDependencies": {
-    "concat-stream": "~1.5.0",
+    "concat-stream": "~1.5.1",
     "falafel": "~1.2.0",
     "js-yaml": "^3.3.1",
-    "tap": "~0.7.1",
+    "tap": "~2.1.1",
     "tap-parser": "^1.1.6"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "through": "~2.3.4"
   },
   "devDependencies": {
-    "concat-stream": "~1.4.1",
-    "falafel": "~1.0.1",
+    "concat-stream": "~1.5.0",
+    "falafel": "~1.2.0",
     "js-yaml": "^3.3.1",
     "tap": "~0.7.1",
     "tap-parser": "^1.1.6"

--- a/test/only.js
+++ b/test/only.js
@@ -1,54 +1,39 @@
 var tap = require('tap');
 var tape = require('../');
-var trim = require('string.prototype.trim');
+var tapParser = require('tap-parser');
 
 tap.test('tape only test', function (tt) {
-    var test = tape.createHarness({ exit: false });
-    var tc = tap.createConsumer();
+    var test = tape.createHarness();
+    var stream = test.createStream();
+    var parser = stream.pipe(tapParser());
+
     var ran = [];
 
-    var rows = []
-    tc.on('data', function (r) { rows.push(r) })
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id: r.id, ok: r.ok, name: trim(r.name) };
-            }
-            else {
-                return r;
-            }
-        })
-
-        tt.deepEqual(rs, [
-            'TAP version 13',
-            'run success',
-            { id: 1, ok: true, name: 'assert name'},
-            'tests 1',
-            'pass  1',
-            'ok'
-        ])
-        tt.deepEqual(ran, [ 3 ]);
-
-        tt.end()
-    })
-
-    test.createStream().pipe(tc)
+    parser.once('assert', function (data) {
+        tt.deepEqual(data, {
+            id: 1,
+            name: "assert name",
+            ok: true
+        });
+        tt.deepEqual(ran, [3]);
+        tt.end();
+    });
 
     test("never run fail", function (t) {
         ran.push(1);
-        t.equal(true, false)
-        t.end()
-    })
+        t.equal(true, false);
+        t.end();
+    });
 
     test("never run success", function (t) {
         ran.push(2);
-        t.equal(true, true)
-        t.end()
-    })
+        t.equal(true, true);
+        t.end();
+    });
 
     test.only("run success", function (t) {
         ran.push(3);
-        t.ok(true, "assert name")
-        t.end()
-    })
-})
+        t.ok(true, "assert name");
+        t.end();
+    });
+});

--- a/test/timeoutAfter.js
+++ b/test/timeoutAfter.js
@@ -1,34 +1,27 @@
 var tape = require('../');
 var tap = require('tap');
+var tapParser = require('tap-parser');
 var trim = require('string.prototype.trim');
 
 tap.test('timeoutAfter test', function (tt) {
     tt.plan(1);
     
     var test = tape.createHarness();
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
+    var stream = test.createStream();
+    var parser = stream.pipe(tapParser());
+
+    parser.once('assert', function (data) {
+        tt.deepEqual(data, {
+            diag: {
+                operator: "fail"
+            },
+            id: 1,
+            name: "test timed out after 1ms",
+            ok: false
         });
-        tt.same(rs, [
-            'TAP version 13',
-            'timeoutAfter',
-            { id: 1, ok: false, name: 'test timed out after 1ms' },
-            'tests 1',
-            'pass  0',
-            'fail  1'
-        ]);
     });
-    
-    test.createStream().pipe(tc);
-    
+
+
     test('timeoutAfter', function (t) {
         t.plan(1);
         t.timeoutAfter(1);

--- a/test/timeoutAfter.js
+++ b/test/timeoutAfter.js
@@ -1,7 +1,6 @@
 var tape = require('../');
 var tap = require('tap');
 var tapParser = require('tap-parser');
-var trim = require('string.prototype.trim');
 
 tap.test('timeoutAfter test', function (tt) {
     tt.plan(1);

--- a/test/too_many.js
+++ b/test/too_many.js
@@ -1,70 +1,43 @@
-var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var tapParser = require('tap-parser');
 
-tap.test('array test', function (tt) {
-    tt.plan(1);
+tap.test('too many test', function (tt) {
+    tt.plan(4);
     
     var test = tape.createHarness({ exit : false });
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        tt.same(rs, [
-            'TAP version 13',
-            'array',
-            { id: 1, ok: true, name: 'should be equivalent' },
-            { id: 2, ok: true, name: 'should be equivalent' },
-            { id: 3, ok: true, name: 'should be equivalent' },
-            { id: 4, ok: true, name: 'should be equivalent' },
-            { id: 5, ok: false, name: 'plan != count' },
-            { id: 6, ok: true, name: 'should be equivalent' },
-            'tests 6',
-            'pass  5',
-            'fail  1'
-        ]);
+    var stream = test.createStream();
+    var parser = stream.pipe(tapParser());
+
+    var asserts = [
+        'true',
+        'empty object',
+        'empty array',
+        'not empty string'
+    ];
+    var i = 0;
+    var plan = 3;
+
+    parser.on('assert', function (data) {
+        var assert = i !== plan + 1
+            ? {
+                id: i + 1,
+                name: asserts[i++] + " is truthy",
+                ok: true
+            } : {
+                id: i++,
+                name: "plan != count",
+                ok: false
+            };
+        tt.deepEqual(data, assert);
     });
-    
-    test.createStream().pipe(tc);
-    
+
     test('array', function (t) {
-        t.plan(3);
-        
-        var src = '(' + function () {
-            var xs = [ 1, 2, [ 3, 4 ] ];
-            var ys = [ 5, 6 ];
-            g([ xs, ys ]);
-        } + ')()';
-        
-        var output = falafel(src, function (node) {
-            if (node.type === 'ArrayExpression') {
-                node.update('fn(' + node.source() + ')');
-            }
-        });
-        
-        var arrays = [
-            [ 3, 4 ],
-            [ 1, 2, [ 3, 4 ] ],
-            [ 5, 6 ],
-            [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
-        ];
-        
-        Function(['fn','g'], output)(
-            function (xs) {
-                t.same(arrays.shift(), xs);
-                return xs;
-            },
-            function (xs) {
-                t.same(xs, [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ]);
-            }
-        );
+        t.plan(plan);
+
+        t.assert(true, 'true is truthy');
+        t.assert({}, 'empty object is truthy');
+        t.assert([], 'empty array is truthy');
+        t.assert('not empty', 'not empty string is truthy');
     });
 });


### PR DESCRIPTION
WIP here is because I can't figure out what should I use instead of `tap.createConsumer` which is missing in node-tap >= 1.0.0. @isaacs is there any alternatives of `createConsumer` method in node-tap 2.2.x?

These tests should be fixed to work with tap 2.1.1
- [ ] array
- [ ] end-as-callback
- [ ] exit
- [ ] fail
- [ ] nested-sync-noplan-noend
- [ ] nested
- [x] only
- [x] timeoutAfter
- [x] too_many