### PR TITLE
Implement shebang using babel-node

### DIFF
--- a/bin/babel-tape
+++ b/bin/babel-tape
@@ -1,0 +1,14 @@
+#!/usr/bin/env babel-node
+
+var path = require('path');
+var glob = require('glob');
+
+process.argv.slice(2).forEach(function (arg) {
+    glob(arg, function (err, files) {
+        files.forEach(function (file) {
+            require(path.resolve(process.cwd(), file));
+        });
+    });
+});
+
+// vim: ft=javascript

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "4.2.2",
   "description": "tap-producing test harness for node and browsers",
   "main": "index.js",
-  "bin": "./bin/tape",
+  "bin": {
+    "tape": "./bin/tape",
+    "babel-tape": "./bin/babel-tape"
+  },
   "directories": {
     "example": "example",
     "test": "test"


### PR DESCRIPTION
Add babel-node functionality to running tape from command line. This
takes advantage of the glob util and handles important es6 features not
covered by —harmony flag (as suggested in https://github.com/substack/tape/issues/102). 