### PR TITLE
Add ES6 support link to documentation.

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -101,6 +101,7 @@ By default, uncaught exceptions in your tests will not be intercepted, and will 
 
 - CoffeeScript support with https://www.npmjs.com/package/coffeetape
 - Promise support with https://www.npmjs.com/package/blue-tape
+- ES6 support with https://www.npmjs.com/package/babel-tape-runner
 
 # methods
 


### PR DESCRIPTION
Running tests as mentioned in
https://github.com/substack/tape/issues/102 does not cover some of the
important es6 features that transpilation does. This is a great tool by
@wavded and I think should be included in the docs!