### PR TITLE
Add tape-promise into 'other'

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -127,7 +127,7 @@ By default, uncaught exceptions in your tests will not be intercepted, and will 
 ## other
 
 - CoffeeScript support with https://www.npmjs.com/package/coffeetape
-- Promise support with https://www.npmjs.com/package/blue-tape
+- Promise support with https://www.npmjs.com/package/blue-tape or https://www.npmjs.com/package/tape-promise
 - ES6 support with https://www.npmjs.com/package/babel-tape-runner or https://www.npmjs.com/package/buble-tape-runner
 - Different test syntax with https://github.com/pguth/flip-tape (warning: mutates String.prototype)
 


### PR DESCRIPTION
Unlike [`blue-tape`](https://www.npmjs.com/package/blue-tape), [`tape-promise`](https://github.com/jprichardson/tape-promise) has the following benefits:
1. Doesn't explicitly depend upon `tape`. i.e. can directly modify `tape` if need be and not fixed to the `tape` version of `blue-tape`.
2. Explicitly supports async/await.
3. Has better documentation.
