### PR TITLE
Add few tap reporters

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -89,6 +89,8 @@ that will output something pretty if you pipe TAP into them:
  - https://github.com/aghassemi/tap-xunit
  - https://github.com/namuol/tap-difflet
  - https://github.com/gritzko/tape-dom
+ - https://github.com/axross/tap-diff
+ - https://github.com/axross/tap-notify
 
 To use them, try `node test/index.js | tap-spec` or pipe it into one
 of the modules of your choice!

--- a/readme.markdown
+++ b/readme.markdown
@@ -15,10 +15,10 @@ var test = require('tape');
 
 test('timing test', function (t) {
     t.plan(2);
-
+    
     t.equal(typeof Date.now, 'function');
     var start = Date.now();
-
+    
     setTimeout(function () {
         t.equal(Date.now() - start, 100);
     }, 100);
@@ -116,13 +116,13 @@ var test = require('tape')
 
 ## test([name], [opts], cb)
 
-Create a new test with an optional `name` string and optional `opts` object.
+Create a new test with an optional `name` string and optional `opts` object. 
 `cb(t)` fires with the new test object `t` once all preceeding tests have
 finished. Tests execute serially.
 
 Available `opts` options are:
 - opts.skip = true/false. See test.skip.
-- opts.timeout = 500. Set a timeout for the test, after which it will fail.
+- opts.timeout = 500. Set a timeout for the test, after which it will fail. 
   See test.timeoutAfter.
 
 If you forget to `t.plan()` out how many assertions you are going to run and you
@@ -156,7 +156,7 @@ Generate a passing assertion with a message `msg`.
 Automatically timeout the test after X ms.
 
 ## t.skip(msg)
-
+ 
 Generate an assertion that will be skipped over.
 
 ## t.ok(value, msg)

--- a/readme.markdown
+++ b/readme.markdown
@@ -15,10 +15,10 @@ var test = require('tape');
 
 test('timing test', function (t) {
     t.plan(2);
-    
+
     t.equal(typeof Date.now, 'function');
     var start = Date.now();
-    
+
     setTimeout(function () {
         t.equal(Date.now() - start, 100);
     }, 100);
@@ -114,13 +114,13 @@ var test = require('tape')
 
 ## test([name], [opts], cb)
 
-Create a new test with an optional `name` string and optional `opts` object. 
+Create a new test with an optional `name` string and optional `opts` object.
 `cb(t)` fires with the new test object `t` once all preceeding tests have
 finished. Tests execute serially.
 
 Available `opts` options are:
 - opts.skip = true/false. See test.skip.
-- opts.timeout = 500. Set a timeout for the test, after which it will fail. 
+- opts.timeout = 500. Set a timeout for the test, after which it will fail.
   See test.timeoutAfter.
 
 If you forget to `t.plan()` out how many assertions you are going to run and you
@@ -154,7 +154,7 @@ Generate a passing assertion with a message `msg`.
 Automatically timeout the test after X ms.
 
 ## t.skip(msg)
- 
+
 Generate an assertion that will be skipped over.
 
 ## t.ok(value, msg)


### PR DESCRIPTION
I created two TAP reporters. Could you add these to [README#pretty reporters](https://github.com/substack/tape#pretty-reporters)?

### [tap-notify](https://github.com/axross/tap-notify)

the Notifier for the TAP. This pass through TAP messages to `stdout`. You can use as `tape *.test.js | tap-notify | tap-some-reporter`.

![screenshot1](https://cloud.githubusercontent.com/assets/4289883/11167356/79ce98be-8ba2-11e5-821d-16d4c21fa3a7.png)

![screenshot2](https://cloud.githubusercontent.com/assets/4289883/11167357/7ade3ae8-8ba2-11e5-8af4-7038dcbf1511.png)

### [tap-diff](https://github.com/axross/tap-diff)

Simple reporter. This shows diffs when assertion failed.

![screenshot3](https://cloud.githubusercontent.com/assets/4289883/11167918/9962e018-8bbb-11e5-9a22-740b95881d84.png)


![screenshot4](https://cloud.githubusercontent.com/assets/4289883/11167370/f588798e-8ba2-11e5-8f38-1c4203a6460d.png)
