### PR TITLE
Removed unreachable Results.prototype.only code

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -84,11 +84,6 @@ Results.prototype.push = function (t) {
 };
 
 Results.prototype.only = function (name) {
-    if (this._only) {
-        self.count ++;
-        self.fail ++;
-        write('not ok ' + self.count + ' already called .only()\n');
-    }
     this._only = name;
 };
 

--- a/test/only-twice.js
+++ b/test/only-twice.js
@@ -1,0 +1,21 @@
+var tape = require('../');
+var tap = require('tap');
+
+tap.test('only twice error', function (assert) {
+  var test = tape.createHarness({ exit : false });
+
+  test.only("first only", function (t) {
+    t.end()
+  });
+
+  assert.throws(function() {
+    test.only('second only', function(t) {
+      t.end();
+    });
+  }, {
+    name: 'Error',
+    message: 'there can only be one only test'
+  });
+  assert.end();
+});
+


### PR DESCRIPTION
I was looking though the results.js file and noticed invalid code.
```js
if (this._only) {
  self.count ++;
  self.fail ++;
  write('not ok ' + self.count + ' already called .only()\n');
}
```
`self` and `write` are not defined. I tried to write a failing test, but found out that the code was unreachable because there is a similar check in index.js before reaching this code.
```js
if (only) throw new Error('there can only be one only test');
results.only(name);
```

This pull requests removes the broken unreachable code. I also added a test for duplicate `test.only` calls.