### PR TITLE
Add flag to require modules before running tests

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -1,12 +1,32 @@
 #!/usr/bin/env node
 
-var path = require('path');
+var resolveModule = require('resolve').sync;
+var resolvePath = require('path').resolve;
+var parseOpts = require('minimist');
 var glob = require('glob');
 
-process.argv.slice(2).forEach(function (arg) {
+var opts = parseOpts(process.argv.slice(2), {
+        alias: { 'r': 'require' },
+        string: 'require',
+        default: {'r': [] }
+    });
+
+var cwd = process.cwd();
+
+/* If only one require is specified, the value of `opts.require`
+ * will be a string. This is why we concatenate.
+ */
+;[].concat(opts.require).forEach(function(module) {
+    /* The `module &&` ensures we ignore `-r ""`, trailing `-r` or other
+     * silly things the user might (inadvertedly) be doing.
+     */
+    module && require(resolveModule(module, { basedir: cwd }));
+});
+
+opts._.forEach(function (arg) {
     glob(arg, function (err, files) {
         files.forEach(function (file) {
-            require(path.resolve(process.cwd(), file));
+            require(resolvePath(cwd, file));
         });
     });
 });

--- a/bin/tape
+++ b/bin/tape
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-require('source-map-support/register');
 
 var path = require('path');
 var glob = require('glob');

--- a/bin/tape
+++ b/bin/tape
@@ -18,10 +18,11 @@ if (typeof opts.require === 'string') {
 }
 
 opts.require.forEach(function(module) {
-    /* The `module &&` ensures we ignore `-r ""`, trailing `-r` or other
-     * silly things the user might (inadvertedly) be doing.
-     */
-    module && require(resolveModule(module, { basedir: cwd }));
+    if (module) {
+      /* This check ensures we ignore `-r ""`, trailing `-r`, or
+       * other silly things the user might (inadvertedly) be doing. */
+      require(resolveModule(module, { basedir: cwd }));
+    }
 });
 
 opts._.forEach(function (arg) {

--- a/bin/tape
+++ b/bin/tape
@@ -13,10 +13,11 @@ var opts = parseOpts(process.argv.slice(2), {
 
 var cwd = process.cwd();
 
-/* If only one require is specified, the value of `opts.require`
- * will be a string. This is why we concatenate.
- */
-;[].concat(opts.require).forEach(function(module) {
+if (typeof opts.require === 'string') {
+  opts.require = [opts.require];
+}
+
+opts.require.forEach(function(module) {
     /* The `module &&` ensures we ignore `-r ""`, trailing `-r` or other
      * silly things the user might (inadvertedly) be doing.
      */

--- a/bin/tape
+++ b/bin/tape
@@ -14,7 +14,7 @@ var opts = parseOpts(process.argv.slice(2), {
 var cwd = process.cwd();
 
 if (typeof opts.require === 'string') {
-  opts.require = [opts.require];
+    opts.require = [opts.require];
 }
 
 opts.require.forEach(function(module) {

--- a/bin/tape
+++ b/bin/tape
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('source-map-support/register');
 
 var path = require('path');
 var glob = require('glob');

--- a/bin/tape
+++ b/bin/tape
@@ -20,7 +20,7 @@ if (typeof opts.require === 'string') {
 opts.require.forEach(function(module) {
     if (module) {
       /* This check ensures we ignore `-r ""`, trailing `-r`, or
-       * other silly things the user might (inadvertedly) be doing. */
+       * other silly things the user might (inadvertently) be doing. */
       require(resolveModule(module, { basedir: cwd }));
     }
 });

--- a/bin/tape
+++ b/bin/tape
@@ -6,9 +6,9 @@ var parseOpts = require('minimist');
 var glob = require('glob');
 
 var opts = parseOpts(process.argv.slice(2), {
-        alias: { 'r': 'require' },
+        alias: { r: 'require' },
         string: 'require',
-        default: {'r': [] }
+        default: { r: [] }
     });
 
 var cwd = process.cwd();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "glob": "~5.0.3",
     "has": "~1.0.1",
     "inherits": "~2.0.1",
+    "minimist": "1.2.0",
     "object-inspect": "~1.0.0",
+    "resolve": "1.1.6",
     "resumer": "~0.0.0",
     "string.prototype.trim": "^1.1.1",
     "through": "~2.3.4"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "inherits": "~2.0.1",
     "object-inspect": "~1.0.0",
     "resumer": "~0.0.0",
-    "source-map-support": "~0.4.0",
     "string.prototype.trim": "^1.1.1",
     "through": "~2.3.4"
   },

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "glob": "~5.0.3",
     "has": "~1.0.1",
     "inherits": "~2.0.1",
-    "minimist": "1.2.0",
+    "minimist": "~1.2.0",
     "object-inspect": "~1.0.0",
-    "resolve": "1.1.6",
+    "resolve": "~1.1.6",
     "resumer": "~0.0.0",
     "string.prototype.trim": "^1.1.1",
     "through": "~2.3.4"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "inherits": "~2.0.1",
     "object-inspect": "~1.0.0",
     "resumer": "~0.0.0",
+    "source-map-support": "~0.4.0",
     "string.prototype.trim": "^1.1.1",
     "through": "~2.3.4"
   },

--- a/readme.markdown
+++ b/readme.markdown
@@ -64,6 +64,26 @@ $ tape 'tests/**/*.js'
 $ tape "tests/**/*.js"
 ```
 
+## Preloading modules
+
+Additionally, it is possible to make `tape` load one or more modules before running any tests, by using the `-r` or `--require` flag. Here's an example that loads [babel-register](http://babeljs.io/docs/usage/require/) before running any tests, to allow for JIT compilation:
+
+```sh
+$ tape -r babel-register tests/**/*.js
+```
+
+Depending on the module you're loading, you may be able to paramaterize it using environment variables or auxiliary files. Babel, for instance, will load options from [`.babelrc`](http://babeljs.io/docs/usage/babelrc/) at runtime.
+
+The `-r` flag behaves exactly like node's `require`, and uses the same module resolution algorithm. This means that if you need to load local modules, you have to prepend their path with `./` or `../` accordingly.
+
+For example:
+
+```sh
+$ tape -r ./my/local/module tests/**/*.js
+```
+
+Please note that modules that all modules loaded using the `-r` flag will run *before* any tests, regardless of when they are specified. For example, `tape -r a b -r c` will actually load `a` and `c` *before` loading `b`, since they are flagged as required modules.
+
 # things that go well with tape
 
 tape maintains a fairly minimal core. Additional features are usually added by using another module alongside tape.

--- a/test/require.js
+++ b/test/require.js
@@ -1,0 +1,83 @@
+var tap = require('tap');
+var spawn = require('child_process').spawn;
+var trim = require('string.prototype.trim');
+
+tap.test('requiring a single module', function (t) {
+    t.plan(2);
+    
+    var tc = tap.createConsumer();
+    
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, [
+            'TAP version 13',
+            'module-a',
+            { id: 1, ok: true, name: 'loaded module a' },
+            'test-a',
+            { id: 2, ok: true, name: 'module-a loaded in same context'},
+            { id: 3, ok: true, name: 'test ran after module-a was loaded'},
+            'tests 3',
+            'pass  3',
+            'ok'
+        ]);
+    });
+    
+    var ps = tape('-r ./require/a require/test-a.js');
+    ps.stdout.pipe(tc);
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});
+
+tap.test('requiring multiple modules', function (t) {
+    t.plan(2);
+    
+    var tc = tap.createConsumer();
+    
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, [
+            'TAP version 13',
+            'module-a',
+            { id: 1, ok: true, name: 'loaded module a' },
+            'module-b',
+            { id: 2, ok: true, name: 'loaded module b' },
+            'test-a',
+            { id: 3, ok: true, name: 'module-a loaded in same context'},
+            { id: 4, ok: true, name: 'test ran after module-a was loaded'},
+            'test-b',
+            { id: 5, ok: true, name: 'module-b loaded in same context'},
+            { id: 6, ok: true, name: 'test ran after module-b was loaded'},
+            'tests 6',
+            'pass  6',
+            'ok'
+        ]);
+    });
+    
+    var ps = tape('-r ./require/a -r ./require/b require/test-a.js require/test-b.js');
+    ps.stdout.pipe(tc);
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});
+
+function tape(args) {
+  var proc = require('child_process')
+  var bin = __dirname + '/../bin/tape'
+
+  return proc.spawn(bin, args.split(' '), { cwd: __dirname })
+}

--- a/test/require/a.js
+++ b/test/require/a.js
@@ -1,0 +1,8 @@
+var tape = require('../..');
+
+tape.test('module-a', function(t) {
+  t.pass('loaded module a')
+  t.end()
+})
+
+global.module_a = true

--- a/test/require/b.js
+++ b/test/require/b.js
@@ -1,0 +1,8 @@
+var tape = require('../..');
+
+tape.test('module-b', function(t) {
+  t.pass('loaded module b')
+  t.end()
+})
+
+global.module_b = true

--- a/test/require/test-a.js
+++ b/test/require/test-a.js
@@ -1,0 +1,7 @@
+var tape = require('../..');
+
+tape.test('test-a', function(t) {
+  t.ok(global.module_a, 'module-a loaded in same context')
+  t.pass('test ran after module-a was loaded')
+  t.end()
+})

--- a/test/require/test-b.js
+++ b/test/require/test-b.js
@@ -1,0 +1,7 @@
+var tape = require('../..');
+
+tape.test('test-b', function(t) {
+  t.ok(global.module_b, 'module-b loaded in same context')
+  t.pass('test ran after module-b was loaded')
+  t.end()
+})


### PR DESCRIPTION
By adding the `--require` flag (and `-r` alias) we allow users to require modules before running their tests. An example of this might be adding source-map-support, like so:

```bash
$ tape -r source-map-support/register test/*.js
```

Another example might be to install the [babel require hook](http://babeljs.io/docs/usage/require/):

```bash
$ tape -r babel-register test/*.js
```

Another potential benefit is the ability to more easily run external test suites: 

```bash
$ npm install test-suite-rfc1337
$ tape -r test-suite-rfc1337
```

Modules are found using the node module resolution algorithm, so if one wants to load a local module it is necessary to prepend `./` or `../`, like so:

```bash
$ tape -r ./my/local/module
```