### PR TITLE
Add return values to assertion methods

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -264,10 +264,12 @@ Test.prototype._assert = function assert (ok, opts) {
             actual : self._plan - pendingAsserts
         });
     }
+
+    return ok;
 };
 
 Test.prototype.fail = function (msg, extra) {
-    this._assert(false, {
+    return this._assert(false, {
         message : msg,
         operator : 'fail',
         extra : extra
@@ -275,7 +277,7 @@ Test.prototype.fail = function (msg, extra) {
 };
 
 Test.prototype.pass = function (msg, extra) {
-    this._assert(true, {
+    return this._assert(true, {
         message : msg,
         operator : 'pass',
         extra : extra
@@ -283,7 +285,7 @@ Test.prototype.pass = function (msg, extra) {
 };
 
 Test.prototype.skip = function (msg, extra) {
-    this._assert(true, {
+    return this._assert(true, {
         message : msg,
         operator : 'skip',
         skip : true,
@@ -295,7 +297,7 @@ Test.prototype.ok
 = Test.prototype['true']
 = Test.prototype.assert
 = function (value, msg, extra) {
-    this._assert(value, {
+    return this._assert(value, {
         message : msg,
         operator : 'ok',
         expected : true,
@@ -308,7 +310,7 @@ Test.prototype.notOk
 = Test.prototype['false']
 = Test.prototype.notok
 = function (value, msg, extra) {
-    this._assert(!value, {
+    return this._assert(!value, {
         message : msg,
         operator : 'notOk',
         expected : false,
@@ -322,7 +324,7 @@ Test.prototype.error
 = Test.prototype.ifErr
 = Test.prototype.iferror
 = function (err, msg, extra) {
-    this._assert(!err, {
+    return this._assert(!err, {
         message : defined(msg, String(err)),
         operator : 'error',
         actual : err,
@@ -337,7 +339,7 @@ Test.prototype.equal
 = Test.prototype.strictEqual
 = Test.prototype.strictEquals
 = function (a, b, msg, extra) {
-    this._assert(a === b, {
+    return this._assert(a === b, {
         message : defined(msg, 'should be equal'),
         operator : 'equal',
         actual : a,
@@ -356,7 +358,7 @@ Test.prototype.notEqual
 = Test.prototype.doesNotEqual
 = Test.prototype.isInequal
 = function (a, b, msg, extra) {
-    this._assert(a !== b, {
+    return this._assert(a !== b, {
         message : defined(msg, 'should not be equal'),
         operator : 'notEqual',
         actual : a,
@@ -370,7 +372,7 @@ Test.prototype.deepEqual
 = Test.prototype.isEquivalent
 = Test.prototype.same
 = function (a, b, msg, extra) {
-    this._assert(deepEqual(a, b, { strict: true }), {
+    return this._assert(deepEqual(a, b, { strict: true }), {
         message : defined(msg, 'should be equivalent'),
         operator : 'deepEqual',
         actual : a,
@@ -383,7 +385,7 @@ Test.prototype.deepLooseEqual
 = Test.prototype.looseEqual
 = Test.prototype.looseEquals
 = function (a, b, msg, extra) {
-    this._assert(deepEqual(a, b), {
+    return this._assert(deepEqual(a, b), {
         message : defined(msg, 'should be equivalent'),
         operator : 'deepLooseEqual',
         actual : a,
@@ -401,7 +403,7 @@ Test.prototype.notDeepEqual
 = Test.prototype.isNotEquivalent
 = Test.prototype.isInequivalent
 = function (a, b, msg, extra) {
-    this._assert(!deepEqual(a, b, { strict: true }), {
+    return this._assert(!deepEqual(a, b, { strict: true }), {
         message : defined(msg, 'should not be equivalent'),
         operator : 'notDeepEqual',
         actual : a,
@@ -414,7 +416,7 @@ Test.prototype.notDeepLooseEqual
 = Test.prototype.notLooseEqual
 = Test.prototype.notLooseEquals
 = function (a, b, msg, extra) {
-    this._assert(!deepEqual(a, b), {
+    return this._assert(!deepEqual(a, b), {
         message : defined(msg, 'should be equivalent'),
         operator : 'notDeepLooseEqual',
         actual : a,
@@ -452,7 +454,7 @@ Test.prototype['throws'] = function (fn, expected, msg, extra) {
         caught.error = caught.error.constructor;
     }
 
-    this._assert(passed, {
+    return this._assert(passed, {
         message : defined(msg, 'should throw'),
         operator : 'throws',
         actual : caught && caught.error,
@@ -474,7 +476,7 @@ Test.prototype.doesNotThrow = function (fn, expected, msg, extra) {
     catch (err) {
         caught = { error : err };
     }
-    this._assert(!caught, {
+    return this._assert(!caught, {
         message : defined(msg, 'should not throw'),
         operator : 'throws',
         actual : caught && caught.error,

--- a/readme.markdown
+++ b/readme.markdown
@@ -128,7 +128,8 @@ By default, uncaught exceptions in your tests will not be intercepted, and will 
 # methods
 
 The assertion methods in tape are heavily influenced or copied from the methods
-in [node-tap](https://github.com/isaacs/node-tap).
+in [node-tap](https://github.com/isaacs/node-tap). One notable exception is all
+assertion methods return `true` if the tests passed, and `false` otherwise.
 
 ```
 var test = require('tape')

--- a/test/return-values.js
+++ b/test/return-values.js
@@ -1,0 +1,22 @@
+var test = require('../');
+
+// fail
+test('pass always returns true', makeTest('pass', [false]));
+test('ok returns true if true', makeTest('ok', [true]));
+test('notOk returns true if false', makeTest('notOk', [false]));
+test('error returns true if error', makeTest('error', [false]));
+test('equals returns true for the same values', makeTest('equal', [1, 1]));
+test('not returns true for different values', makeTest('notEqual', [1, 2]));
+test('deepEqual returns true when equivalent', makeTest('deepEqual', [{}, {}]));
+test('deepLooseEqual returns true when deep equal', makeTest('looseEqual', [{}, {}]));
+test('notDeepEqual returns true when not the same', makeTest('notDeepEqual', [{}, [1]]));
+test('notLooseEqual returns true when not deep equal', makeTest('notDeepLooseEqual', [{}, [1]]));
+test('throws returns true if the function throws', makeTest('throws', [function() { throw new Error(); }, Error]));
+test('doesNotThrow returns true if the function does not throw', makeTest('doesNotThrow', [function() {}, null]));
+
+function makeTest(f, args) {
+  return function (t) {
+    t.equal(t[f].apply(t, args), true);
+    t.end();
+  }
+}


### PR DESCRIPTION
I am using [jsverify](https://github.com/jsverify/jsverify) for property testing. `jsverify` terminates early if it returns false. I noticed that there was no way to see if the test succeeds or fails in `tape` for me to return `false`. I am not trying to force ideas from other libraries into `tape`, however returning nothing (`undefined`) doesn't seem to provide any benefit. This will allow people to know if the test succeeds for similar needs.

I know that this does not test all the cases, but I could not find a good way to test when it should fail. If you have an idea on how to improve the tests, I can fix them.

Here is what merging this would allow others to do. There are probably other cases when this would provide benefit, but I don't have an exhaustive list.

```
test('magic', function (t) {
  jsc.assert(jsc.forall("number", "number", function(a, b) {
    // I need to return true if the property holds, and false if it is violated. jsverify will then stop
    // generating data. If a specific number pass (default 100), then the property is assumed to "hold".
    // I have no way to know if `t.equal(a, add(a, b))` succeeds or fails to return the proper value for
    // jsverify.
    return t.equal(a, add(a, b));
  }));
  t.end();
});

function add(a, b) { return a + b; }
```
