### PR TITLE
Async test setup

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -63,16 +63,27 @@ Results.prototype.createStream = function (opts) {
         output.queue('TAP version 13\n');
         self._stream.pipe(output);
     }
-    
+
     nextTick(function next() {
         var t;
         while (t = getNextTest(self)) {
             t.run();
-            if (!t.ended) return t.once('end', function(){ nextTick(next); });
+
+            function end(){
+                if(opts.completeWait){
+                    opts.completeWait(function(){
+                        nextTick(next);
+                    });
+                }else{
+                    nextTick(next);
+                }
+            }
+
+            if (!t.ended) return t.once('end', end);
         }
         self.emit('done');
     });
-    
+
     return output;
 };
 
@@ -93,7 +104,7 @@ Results.prototype._watch = function (t) {
     t.once('prerun', function () {
         write('# ' + t.name + '\n');
     });
-    
+
     t.on('result', function (res) {
         if (typeof res === 'string') {
             write('# ' + res + '\n');
@@ -105,7 +116,7 @@ Results.prototype._watch = function (t) {
         if (res.ok) self.pass ++
         else self.fail ++
     });
-    
+
     t.on('test', function (st) { self._watch(st) });
 };
 
@@ -114,7 +125,7 @@ Results.prototype.close = function () {
     if (self.closed) self._stream.emit('error', new Error('ALREADY CLOSED'));
     self.closed = true;
     var write = function (s) { self._stream.queue(s) };
-    
+
     write('\n1..' + self.count + '\n');
     write('# tests ' + self.count + '\n');
     write('# pass  ' + self.pass + '\n');
@@ -128,22 +139,22 @@ function encodeResult (res, count) {
     var output = '';
     output += (res.ok ? 'ok ' : 'not ok ') + count;
     output += res.name ? ' ' + res.name.toString().replace(/\s+/g, ' ') : '';
-    
+
     if (res.skip) output += ' # SKIP';
     else if (res.todo) output += ' # TODO';
-    
+
     output += '\n';
     if (res.ok) return output;
-    
+
     var outer = '  ';
     var inner = outer + '  ';
     output += outer + '---\n';
     output += inner + 'operator: ' + res.operator + '\n';
-    
+
     if (has(res, 'expected') || has(res, 'actual')) {
         var ex = inspect(res.expected);
         var ac = inspect(res.actual);
-        
+
         if (Math.max(ex.length, ac.length) > 65 || invalidYaml(ex) || invalidYaml(ac)) {
             output += inner + 'expected: |-\n' + inner + '  ' + ex + '\n';
             output += inner + 'actual: |-\n' + inner + '  ' + ac + '\n';
@@ -163,7 +174,7 @@ function encodeResult (res, count) {
             output += inner + '  ' + lines[i] + '\n';
         }
     }
-    
+
     output += outer + '...\n';
     return output;
 }
@@ -172,7 +183,7 @@ function getNextTest (results) {
     if (!results._only) {
         return results.tests.shift();
     }
-    
+
     do {
         var t = results.tests.shift();
         if (!t) continue;

--- a/lib/results.js
+++ b/lib/results.js
@@ -7,6 +7,7 @@ var bind = require('function-bind');
 var has = require('has');
 var regexpTest = bind.call(Function.call, RegExp.prototype.test);
 var yamlIndicators = /\:|\-|\?/;
+var debounce = require('debounce');
 var nextTick = typeof setImmediate !== 'undefined'
     ? setImmediate
     : process.nextTick
@@ -64,25 +65,21 @@ Results.prototype.createStream = function (opts) {
         self._stream.pipe(output);
     }
 
-    nextTick(function next() {
-        var t;
-        while (t = getNextTest(self)) {
-            t.run();
 
-            function end(){
-                if(opts.completeWait){
-                    opts.completeWait(function(){
-                        nextTick(next);
-                    });
-                }else{
-                    nextTick(next);
-                }
+    var end = debounce(function () {
+        nextTick(function(){
+            var t;
+            while (t = getNextTest(self)) {
+                t.run();
+
+                if (!t.ended) return t.once('end', end);
             }
 
-            if (!t.ended) return t.once('end', end);
-        }
-        self.emit('done');
-    });
+            self.emit('done');
+        });
+    }, opts.endWaitTime || 0);
+
+    end();
 
     return output;
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "test"
   },
   "dependencies": {
+    "debounce": "^1.0.0",
     "deep-equal": "~1.0.0",
     "defined": "~1.0.0",
     "function-bind": "~1.0.2",

--- a/test/async.js
+++ b/test/async.js
@@ -1,0 +1,41 @@
+var falafel = require('falafel');
+var tape = require('../');
+var tap = require('tap');
+var trim = require('string.prototype.trim');
+
+tap.test('async test calls', function (tt) {
+    tt.plan(1);
+
+    var test = tape.createHarness();
+    var tc = tap.createConsumer();
+
+    test.createStream().pipe(tc);
+
+    function run1(callback){
+        test('first', function (t) {
+            t.plan(1);
+
+            t.pass();
+
+            setTimeout(callback, 50);
+        });
+    }
+
+    function run2(callback){
+        test('second', function (t) {
+            t.plan(1);
+
+            t.pass();
+
+            setTimeout(callback, 50);
+        });
+    }
+
+    run1(function(){
+        setTimeout(function(){
+            run2(function(){
+                tt.pass();
+            });
+        });
+    });
+});

--- a/test/async.js
+++ b/test/async.js
@@ -7,12 +7,7 @@ tap.test('async test calls', function (tt) {
     var test = tape.createHarness();
     var tc = tap.createConsumer();
 
-    test.createStream({
-        completeWait: function(callback){
-            console.log('x');
-            setTimeout(callback, 20);
-        }
-    }).pipe(tc);
+    test.createStream({endWaitTime: 20}).pipe(tc);
 
     function run1(callback){
         test('first', function (t) {

--- a/test/async.js
+++ b/test/async.js
@@ -7,7 +7,12 @@ tap.test('async test calls', function (tt) {
     var test = tape.createHarness();
     var tc = tap.createConsumer();
 
-    test.createStream().pipe(tc);
+    test.createStream({
+        completeWait: function(callback){
+            console.log('x');
+            setTimeout(callback, 20);
+        }
+    }).pipe(tc);
 
     function run1(callback){
         test('first', function (t) {
@@ -15,7 +20,7 @@ tap.test('async test calls', function (tt) {
 
             t.pass();
 
-            setTimeout(callback, 1);
+            setTimeout(callback, 10);
         });
     }
 
@@ -25,7 +30,7 @@ tap.test('async test calls', function (tt) {
 
             t.pass();
 
-            setTimeout(callback, 1);
+            setTimeout(callback, 10);
         });
     }
 

--- a/test/async.js
+++ b/test/async.js
@@ -1,7 +1,5 @@
-var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
 
 tap.test('async test calls', function (tt) {
     tt.plan(1);
@@ -17,7 +15,7 @@ tap.test('async test calls', function (tt) {
 
             t.pass();
 
-            setTimeout(callback, 50);
+            setTimeout(callback, 1);
         });
     }
 
@@ -27,15 +25,13 @@ tap.test('async test calls', function (tt) {
 
             t.pass();
 
-            setTimeout(callback, 50);
+            setTimeout(callback, 1);
         });
     }
 
     run1(function(){
-        setTimeout(function(){
-            run2(function(){
-                tt.pass();
-            });
+        run2(function(){
+            tt.pass();
         });
     });
 });


### PR DESCRIPTION
As per https://github.com/substack/tape/issues/234

Attempting to call additional tests after some delay causes tape to hang. 

This branch resolves by the addition of the `endWaitTime` option.

By default, there is no wait time, and tape acts as usual.

Setting `endWaitTime` to a value eg `50` causes tape to wait 50ms between t `'end'` events before emitting `'done'`. This allows tests that get set up asynchronously after other tests have completed, to run.

`endWaitTime` is a suggestion, there are probably better names for it.