### PR TITLE
Alternate method of failure line detection (fix for #242)

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -211,39 +211,18 @@ Test.prototype._assert = function assert (ok, opts) {
     if (!ok) {
         var e = new Error('exception');
         var err = (e.stack || '').split('\n');
-        var dir = path.dirname(__dirname) + '/';
-        
         for (var i = 0; i < err.length; i++) {
-            var m = /^[^\s]*\s*\bat\s+(.+)/.exec(err[i]);
-            if (!m) {
-                continue;
-            }
-            
-            var s = m[1].split(/\s+/);
-            var filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
-            if (!filem) {
-                filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[2]);
-                
-                if (!filem) {
-                    filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
-
-                    if (!filem) {
-                        continue;
-                    }
+            var m = /at ([^)]+)\(([^:\s]+):(\d+):(\d+)\)/.exec(err[i]);
+            if (m) {
+                if (m[2].indexOf('test.js') < 0) {
+                    res.functionName = m[1];
+                    res.file = m[2];
+                    res.line = Number(m[3]);
+                    res.column = Number(m[4]);
+                    res.at = m[0].slice(3);
+                    break;
                 }
             }
-            
-            if (filem[1].slice(0, dir.length) === dir) {
-                continue;
-            }
-            
-            res.functionName = s[0];
-            res.file = filem[1];
-            res.line = Number(filem[2]);
-            if (filem[3]) res.column = filem[3];
-            
-            res.at = m[1];
-            break;
         }
     }
 

--- a/test/circular-things.js
+++ b/test/circular-things.js
@@ -4,27 +4,35 @@ var concat = require('concat-stream');
 
 tap.test('circular test', function (assert) {
     var test = tape.createHarness({ exit : false });
-    assert.plan(1);
+    assert.plan(3);
 
     test.createStream().pipe(concat(function (body) {
-        assert.equal(
-            body.toString('utf8'),
-            'TAP version 13\n'
-            + '# circular\n'
-            + 'not ok 1 should be equal\n'
-            + '  ---\n'
-            + '    operator: equal\n'
-            + '    expected: |-\n'
-            + '      {}\n'
-            + '    actual: |-\n'
-            + '      { circular: [Circular] }\n'
-            + '  ...\n'
-            + '\n'
-            + '1..1\n'
-            + '# tests 1\n'
-            + '# pass  0\n'
-            + '# fail  1\n'
-        );
+        var expectedLines = [
+            'TAP version 13',
+            '# circular',
+            'not ok 1 should be equal',
+            '  ---',
+            '    operator: equal',
+            '    expected: |-',
+            '      {}',
+            '    actual: |-',
+            '      { circular: [Circular] }'
+        ];
+        var found = body.toString('utf8').split('\n');
+        assert.equal(found.slice(0, expectedLines.length).join('\n'), expectedLines.join('\n'));
+        // The next line will vary depending on where the test is executed. Match it with a regex
+        assert.ok(/    at:.*circular-things.js:\d+:\d+/.test(found[expectedLines.length]));
+        // Now test the rest
+        found = found.slice(expectedLines.length + 1);
+        expectedLines = [
+            '  ...',
+            '',
+            '1..1',
+            '# tests 1',
+            '# pass  0',
+            '# fail  1\n',
+        ];
+        assert.equal(found.join('\n'), expectedLines.join('\n'));
     }));
 
     test("circular", function (t) {

--- a/test/double_end.js
+++ b/test/double_end.js
@@ -3,25 +3,34 @@ var concat = require('concat-stream');
 var spawn = require('child_process').spawn;
 
 test(function (t) {
-    t.plan(2);
+    t.plan(4);
     var ps = spawn(process.execPath, [ __dirname + '/double_end/double.js' ]);
     ps.on('exit', function (code) {
         t.equal(code, 1);
     });
     ps.stdout.pipe(concat(function (body) {
-        t.equal(body.toString('utf8'), [
+        var expectedLines = [
             'TAP version 13',
             '# double end',
             'ok 1 should be equal',
             'not ok 2 .end() called twice',
             '  ---',
             '    operator: fail',
+        ];
+        var found = body.toString('utf8').split('\n');
+        t.equal(found.slice(0, expectedLines.length).join('\n'), expectedLines.join('\n'));
+        // The next line will vary depending on where the test is executed. Match it with a regex
+        t.ok(/    at:.*double.js:\d+:\d+/.test(found[expectedLines.length]));
+        // Now test the rest
+        found = found.slice(expectedLines.length + 1);
+        expectedLines = [
             '  ...',
             '',
             '1..2',
             '# tests 2',
             '# pass  1',
-            '# fail  1',
-        ].join('\n') + '\n\n');
+            '# fail  1\n\n',
+        ];
+        t.equal(found.join('\n'), expectedLines.join('\n'));
     }));
 });

--- a/test/stackTrace.js
+++ b/test/stackTrace.js
@@ -5,7 +5,7 @@ var tapParser = require('tap-parser');
 var yaml = require('js-yaml');
 
 tap.test('preserves stack trace with newlines', function (tt) {
-    tt.plan(3);
+    tt.plan(7);
 
     var test = tape.createHarness();
     var stream = test.createStream();
@@ -13,6 +13,8 @@ tap.test('preserves stack trace with newlines', function (tt) {
     var stackTrace = 'foo\n  bar';
 
     parser.once('assert', function (data) {
+        tt.ok(/.*stackTrace.js:\d+:\d+/.test(data.diag.at));
+        delete data.diag.at;
         tt.deepEqual(data, {
             ok: false,
             id: 1,
@@ -28,29 +30,41 @@ tap.test('preserves stack trace with newlines', function (tt) {
 
     stream.pipe(concat(function (body) {
         var body = body.toString('utf8')
-        tt.equal(
-            body,
-            'TAP version 13\n'
-            + '# multiline stack trace\n'
-            + 'not ok 1 Error: Preserve stack\n'
-            + '  ---\n'
-            + '    operator: error\n'
-            + '    expected: |-\n'
-            + '      undefined\n'
-            + '    actual: |-\n'
-            + '      [Error: Preserve stack]\n'
-            + '    stack: |-\n'
-            + '      foo\n'
-            + '        bar\n'
-            + '  ...\n'
-            + '\n'
-            + '1..1\n'
-            + '# tests 1\n'
-            + '# pass  0\n'
-            + '# fail  1\n'
-        );
 
-        tt.deepEqual(getDiag(body), {
+        var expectedLines = [
+            'TAP version 13',
+            '# multiline stack trace',
+            'not ok 1 Error: Preserve stack',
+            '  ---',
+            '    operator: error',
+            '    expected: |-',
+            '      undefined',
+            '    actual: |-',
+            '      [Error: Preserve stack]',
+        ];
+        var found = body.split('\n');
+        tt.equal(found.slice(0, expectedLines.length).join('\n'), expectedLines.join('\n'));
+        // The next line will vary depending on where the test is executed. Match it with a regex
+        tt.ok(/    at:.*stackTrace.js:\d+:\d+/.test(found[expectedLines.length]));
+        // Now test the rest
+        found = found.slice(expectedLines.length + 1);
+        expectedLines = [
+            '    stack: |-',
+            '      foo',
+            '        bar',
+            '  ...',
+            '',
+            '1..1',
+            '# tests 1',
+            '# pass  0',
+            '# fail  1\n',
+        ];
+        tt.equal(found.join('\n'), expectedLines.join('\n'));
+
+        found = getDiag(body);
+        tt.ok(/.*stackTrace.js:\d+:\d+/.test(found.at));
+        delete found.at;
+        tt.deepEqual(found, {
             stack: stackTrace,
             operator: 'error',
             expected: 'undefined',

--- a/test/undef.js
+++ b/test/undef.js
@@ -3,28 +3,36 @@ var tap = require('tap');
 var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
-    tt.plan(1);
+    tt.plan(3);
     
     var test = tape.createHarness();
     test.createStream().pipe(concat(function (body) {
-        tt.equal(
-            body.toString('utf8'),
-            'TAP version 13\n'
-            + '# undef\n'
-            + 'not ok 1 should be equivalent\n'
-            + '  ---\n'
-            + '    operator: deepEqual\n'
-            + '    expected: |-\n'
-            + '      { beep: undefined }\n'
-            + '    actual: |-\n'
-            + '      {}\n'
-            + '  ...\n'
-            + '\n'
-            + '1..1\n'
-            + '# tests 1\n'
-            + '# pass  0\n'
-            + '# fail  1\n'
-        );
+        var expectedLines = [
+            'TAP version 13',
+            '# undef',
+            'not ok 1 should be equivalent',
+            '  ---',
+            '    operator: deepEqual',
+            '    expected: |-',
+            '      { beep: undefined }',
+            '    actual: |-',
+            '      {}',
+        ];
+        var found = body.toString('utf8').split('\n');
+        tt.equal(found.slice(0, expectedLines.length).join('\n'), expectedLines.join('\n'));
+        // The next line will vary depending on where the test is executed. Match it with a regex
+        tt.ok(/    at:.*undef.js:\d+:\d+/.test(found[expectedLines.length]));
+        // Now test the rest
+        found = found.slice(expectedLines.length + 1);
+        expectedLines = [
+            '  ...',
+            '',
+            '1..1',
+            '# tests 1',
+            '# pass  0',
+            '# fail  1\n',
+        ];
+        tt.equal(found.join('\n'), expectedLines.join('\n'));
     }));
     
     test('undef', function (t) {


### PR DESCRIPTION
This is a proposed fix for losing "at:" reporting when running tests through babel-node and babel-tape-runner (and possibly other tools that modify code).

The previous detection method searched the error stack for frames that listed files using absolute paths.  It then weeded out ones that were part of the tape module directory.  This works fine when running under node because the unmodified code reports full paths for source files.  Under babel-node and babel-tape-runner, the source files are reported as single file names (e.g. no path).  The detection does not work when this happens.

The new method checks each error stack entry to see if the frame belongs to 'test.js' (which is always where the assertions come from).  When it finds the first frame that is not 'test.js', it reports that as the failure line ("at:").  Admittedly, it would still not report "at:" entries of the end user chooses 'test.js' as their file name, but that seems a reasonable restriction to me for more reliable failure line reporting.

When I made this change, it unfortunately (fortunately?) caused some of the tape unit tests to start reporting "at:" lines.  Though a bit challenging :) due to specific error line reporting, I updated those in this pull request too.

With this change, running the example from issue #242, I now correctly get:

```
$ babel-node foo.js
TAP version 13
# foo
not ok 1 should be equal
  ---
    operator: equal
    expected: 1
    actual:   0
    at: Test.myTest (foo.js:5:7)
  ...

1..1
# tests 1
# pass  0
# fail  1
```
