### PR TITLE
include only necessary files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "tap-producing test harness for node and browsers",
   "main": "index.js",
   "bin": "./bin/tape",
+  "files": ["index.js", "lib/", "bin/"],
   "directories": {
     "example": "example",
     "test": "test"


### PR DESCRIPTION
```
$ tree node_modules/tape -I node_modules

node_modules/tape
├── bin/
│   └── tape*
├── example/
│   ├── static/
│   │   ├── build.sh*
│   │   ├── index.html
│   │   └── server.js
│   ├── stream/
│   │   ├── test/
│   │   │   ├── x.js
│   │   │   └── y.js
│   │   ├── object.js
│   │   └── tap.js
│   ├── array.js
│   ├── fail.js
│   ├── nested.js
│   ├── nested_fail.js
│   ├── not_enough.js
│   ├── throw.js
│   ├── timing.js
│   ├── too_many.js
│   └── two.js
├── lib/
│   ├── default_stream.js
│   ├── results.js
│   └── test.js
├── test/
│   ├── browser/
│   │   └── asserts.js
│   ├── double_end/
│   │   └── double.js
│   ├── exit/
│   │   ├── fail.js
│   │   ├── ok.js
│   │   ├── second.js
│   │   └── too_few.js
│   ├── max_listeners/
│   │   └── source.js
│   ├── require/
│   │   ├── a.js
│   │   ├── b.js
│   │   ├── test-a.js
│   │   └── test-b.js
│   ├── add-subtest-async.js
│   ├── array.js
│   ├── bound.js
│   ├── child_ordering.js
│   ├── circular-things.js
│   ├── deep-equal-failure.js
│   ├── deep.js
│   ├── double_end.js
│   ├── end-as-callback.js
│   ├── exit.js
│   ├── exposed-harness.js
│   ├── fail.js
│   ├── many.js
│   ├── max_listeners.js
│   ├── nested-async-plan-noend.js
│   ├── nested-sync-noplan-noend.js
│   ├── nested.js
│   ├── nested2.js
│   ├── no_callback.js
│   ├── onFinish.js
│   ├── only-twice.js
│   ├── only.js
│   ├── only2.js
│   ├── only3.js
│   ├── order.js
│   ├── plan_optional.js
│   ├── require.js
│   ├── skip.js
│   ├── stackTrace.js
│   ├── subcount.js
│   ├── subtest_and_async.js
│   ├── subtest_plan.js
│   ├── throws.js
│   ├── timeout.js
│   ├── timeoutAfter.js
│   ├── too_many.js
│   └── undef.js
├── .npmignore
├── .travis.yml
├── LICENSE
├── index.js
├── package.json
└── readme.markdown
```

See [NPM docs](https://docs.npmjs.com/files/package.json#files) for details.