### PR TITLE
add message defaults to .ok() and .notOk()

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -302,7 +302,7 @@ Test.prototype.ok
 = Test.prototype.assert
 = function (value, msg, extra) {
     this._assert(value, {
-        message : msg,
+        message : defined(msg, 'should be truthy'),
         operator : 'ok',
         expected : true,
         actual : value,
@@ -315,7 +315,7 @@ Test.prototype.notOk
 = Test.prototype.notok
 = function (value, msg, extra) {
     this._assert(!value, {
-        message : msg,
+        message : defined(msg, 'should be falsy'),
         operator : 'notOk',
         expected : false,
         actual : value,

--- a/test/default-messages.js
+++ b/test/default-messages.js
@@ -1,0 +1,37 @@
+var tap = require('tap');
+var spawn = require('child_process').spawn;
+var trim = require('string.prototype.trim');
+
+tap.test('default messages', function (t) {
+    t.plan(1);
+
+    var tc = tap.createConsumer();
+
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, [
+            'TAP version 13',
+            'default messages',
+            { id: 1, ok: true, name: 'should be truthy' },
+            { id: 2, ok: true, name: 'should be falsy' },
+            { id: 3, ok: true, name: 'should be equal' },
+            { id: 4, ok: true, name: 'should not be equal' },
+            { id: 5, ok: true, name: 'should be equivalent' },
+            { id: 6, ok: true, name: 'should be equivalent' },
+            { id: 7, ok: true, name: 'should be equivalent' },
+            'tests 7',
+            'pass  7',
+            'ok'
+        ]);
+    });
+
+    var ps = spawn(process.execPath, [ __dirname + '/messages/defaults.js' ]);
+    ps.stdout.pipe(tc);
+});

--- a/test/exit.js
+++ b/test/exit.js
@@ -126,9 +126,9 @@ tap.test('more planned in a second test', function (t) {
         t.same(rs, [
             'TAP version 13',
             'first',
-            { id: 1, ok: true, name: '(unnamed assert)' },
+            { id: 1, ok: true, name: 'should be truthy' },
             'second',
-            { id: 2, ok: true, name: '(unnamed assert)' },
+            { id: 2, ok: true, name: 'should be truthy' },
             { id: 3, ok: false, name: 'plan != count' },
             'tests 3',
             'pass  2',

--- a/test/messages/defaults.js
+++ b/test/messages/defaults.js
@@ -1,0 +1,12 @@
+var test = require('../../');
+
+test('default messages', function (t) {
+  t.plan(7);
+  t.ok(true);
+  t.notOk(false);
+  t.equal(true, true);
+  t.notEqual(true, false);
+  t.deepEqual(true, true);
+  t.deepLooseEqual(true, true);
+  t.notDeepLooseEqual(true, false);
+});

--- a/test/nested-sync-noplan-noend.js
+++ b/test/nested-sync-noplan-noend.js
@@ -21,9 +21,9 @@ tap.test('nested sync test without plan or end', function (tt) {
             'TAP version 13',
             'nested without plan or end',
             'first',
-            { id: 1, ok: true, name: '(unnamed assert)' },
+            { id: 1, ok: true, name: 'should be truthy' },
             'second',
-            { id: 2, ok: true, name: '(unnamed assert)' },
+            { id: 2, ok: true, name: 'should be truthy' },
             'tests 2',
             'pass  2',
             'ok'

--- a/test/nested.js
+++ b/test/nested.js
@@ -27,10 +27,10 @@ tap.test('array test', function (tt) {
             { id: 4, ok: true, name: 'should be equivalent' },
             { id: 5, ok: true, name: 'should be equivalent' },
             'inside test',
-            { id: 6, ok: true, name: '(unnamed assert)' },
-            { id: 7, ok: true, name: '(unnamed assert)' },
+            { id: 6, ok: true, name: 'should be truthy' },
+            { id: 7, ok: true, name: 'should be truthy' },
             'another',
-            { id: 8, ok: true, name: '(unnamed assert)' },
+            { id: 8, ok: true, name: 'should be truthy' },
             'tests 8',
             'pass  8',
             'ok'


### PR DESCRIPTION
Just noticed in a reporter that there are really nice test defaults for methods like `.equals`, but `.ok()` and `.notOk()` just say `(unnamed assert)`.

This adds the following default messages:

- `.ok()` - "should be truthy"
- `.notOk()` - "should be falsey"

Also updates the tests where they are expecting the old default value.
