### PR TITLE
show the entire stack when there's an error

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -156,8 +156,10 @@ function encodeResult (res, count) {
     if (res.at) {
         output += inner + 'at: ' + res.at + '\n';
     }
-    if (res.operator === 'error' && res.actual && res.actual.stack) {
-        var lines = String(res.actual.stack).split('\n');
+    var error = (res.actual instanceof Error ? res.actual : res.error)
+    var stack = typeof error === 'object' ? error.stack : null
+    if (stack) {
+        var lines = String(stack).split('\n');
         output += inner + 'stack: |-\n';
         for (var i = 0; i < lines.length; i++) {
             output += inner + '  ' + lines[i] + '\n';

--- a/test/stackTrace.js
+++ b/test/stackTrace.js
@@ -66,6 +66,67 @@ tap.test('preserves stack trace with newlines', function (tt) {
     });
 });
 
+tap.test('preserves stack trace for failed assertions', function (tt) {
+    tt.plan(5);
+
+    var test = tape.createHarness();
+    var stream = test.createStream();
+    var parser = stream.pipe(tapParser());
+
+    var stack = ''
+    parser.once('assert', function (data) {
+        tt.equal(typeof data.diag.stack, 'string')
+        stack = data.diag.stack || ''
+        tt.ok(/^Error: false should be true(\n    at .+)+/.exec(stack), 'stack should be a stack')
+        tt.deepEqual(data, {
+            ok: false,
+            id: 1,
+            name: "false should be true",
+            diag: {
+                stack: stack,
+                operator: 'equal',
+                expected: false,
+                actual: true
+            }
+        });
+    });
+
+    stream.pipe(concat(function (body) {
+        var body = body.toString('utf8')
+        tt.equal(
+            body,
+            'TAP version 13\n'
+            + '# t.equal stack trace\n'
+            + 'not ok 1 false should be true\n'
+            + '  ---\n'
+            + '    operator: equal\n'
+            + '    expected: false\n'
+            + '    actual:   true\n'
+            + '    stack: |-\n'
+            + '      '
+            + stack.replace(/\n/g, '\n      ') + '\n'
+            + '  ...\n'
+            + '\n'
+            + '1..1\n'
+            + '# tests 1\n'
+            + '# pass  0\n'
+            + '# fail  1\n'
+        );
+
+        tt.deepEqual(getDiag(body), {
+            stack: stack,
+            operator: 'equal',
+            expected: false,
+            actual: true
+        });
+    }));
+
+    test('t.equal stack trace', function (t) {
+        t.plan(1);
+        t.equal(true, false, 'false should be true');
+    });
+});
+
 function getDiag (body) {
     var yamlStart = body.indexOf('  ---');
     var yamlEnd = body.indexOf('  ...\n');


### PR DESCRIPTION
related to #68 

I just made it print the entire stack trace.

Sorry about the removal of the trailing spaces, I can't figure out how to get my editor to not do that when I save.
