### PR TITLE
Skipped test blocks should output a “SKIP” message

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -67,6 +67,9 @@ function Test (name_, opts_, cb_) {
 }
 
 Test.prototype.run = function () {
+    if (this._skip) {
+        this.comment('SKIP ' + this.name);
+    }
     if (!this._cb || this._skip) {
         return this._end();
     }

--- a/test/skip.js
+++ b/test/skip.js
@@ -1,6 +1,34 @@
 var test = require('../');
 var ran = 0;
 
+var concat = require('concat-stream');
+var tap = require('tap');
+
+tap.test('test SKIP comment', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            '# SKIP skipped',
+            '',
+            '1..0',
+            '# tests 0',
+            '# pass  0',
+            '',
+            '# ok',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    tapeTest.createStream().pipe(concat(verify));
+    tapeTest('skipped', { skip: true }, function (t) {
+        t.end();
+    });
+});
+
+
 test('do not skip this', { skip: false }, function(t) {
     t.pass('this should run');
     ran ++;


### PR DESCRIPTION
Using the `skip` option to skip a test block currently outputs nothing - whereas `t.skip` outputs as a comment prefixed with "SKIP ". This adds the same behavior to when skipping a test block.