### PR TITLE
Add test for deep loose equal

### DIFF
--- a/test/deep.js
+++ b/test/deep.js
@@ -7,3 +7,11 @@ test('deep strict equal', function (t) {
     );
     t.end();
 });
+
+test('deep loose equal', function (t) {
+    t.deepLooseEqual(
+        [ { a: '3' } ],
+        [ { a: 3 } ]
+    );
+    t.end();
+});


### PR DESCRIPTION
I was experimenting with reducing tape's dependencies and realized that `_.isEqual` doesn't offer a loose equal, but the tests were still passing. This test checks that loose equal works right.