### PR TITLE
Reduce the number of dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
-var defined = require('defined');
 var createDefaultStream = require('./lib/default_stream');
 var Test = require('./lib/test');
 var createResult = require('./lib/results');
+var defined = require('./lib/util').defined;
 var through = require('through');
+var _ = require('underscore');
 
 var canEmitExit = typeof process !== 'undefined' && process
     && typeof process.on === 'function' && process.browser !== true

--- a/lib/results.js
+++ b/lib/results.js
@@ -3,9 +3,9 @@ var inherits = require('inherits');
 var through = require('through');
 var resumer = require('resumer');
 var inspect = require('object-inspect');
-var bind = require('function-bind');
-var has = require('has');
-var regexpTest = bind.call(Function.call, RegExp.prototype.test);
+var _ = require('underscore');
+
+var regexpTest = _.bind(Function.call, RegExp.prototype.test);
 var yamlIndicators = /\:|\-|\?/;
 var nextTick = typeof setImmediate !== 'undefined'
     ? setImmediate
@@ -39,7 +39,7 @@ Results.prototype.createStream = function (opts) {
                     name: t.name,
                     id: id
                 };
-                if (has(extra, 'parent')) {
+                if (_.has(extra, 'parent')) {
                     row.parent = extra.parent;
                 }
                 output.queue(row);
@@ -140,7 +140,7 @@ function encodeResult (res, count) {
     output += outer + '---\n';
     output += inner + 'operator: ' + res.operator + '\n';
     
-    if (has(res, 'expected') || has(res, 'actual')) {
+    if (_.has(res, 'expected') || _.has(res, 'actual')) {
         var ex = inspect(res.expected);
         var ac = inspect(res.actual);
         

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,10 +1,11 @@
 var deepEqual = require('deep-equal');
-var defined = require('defined');
 var path = require('path');
 var inherits = require('inherits');
 var EventEmitter = require('events').EventEmitter;
-var has = require('has');
-var trim = require('string.prototype.trim');
+var _ = require('underscore');
+var util = require('./util');
+var trim = util.trim;
+var defined = util.defined;
 
 module.exports = Test;
 
@@ -199,10 +200,10 @@ Test.prototype._assert = function assert (ok, opts) {
         name : defined(extra.message, opts.message, '(unnamed assert)'),
         operator : defined(extra.operator, opts.operator)
     };
-    if (has(opts, 'actual') || has(extra, 'actual')) {
+    if (_.has(opts, 'actual') || _.has(extra, 'actual')) {
         res.actual = defined(extra.actual, opts.actual);
     }
-    if (has(opts, 'expected') || has(extra, 'expected')) {
+    if (_.has(opts, 'expected') || _.has(extra, 'expected')) {
         res.expected = defined(extra.expected, opts.expected);
     }
     this._ok = Boolean(this._ok && ok);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,20 @@
+var _ = require('underscore');
+
+module.exports.defined = defined;
+
+if (!_.isUndefined(String.prototype.trim)) {
+  module.exports.trim = _.bind(Function.call, String.prototype.trim);
+} else {
+  module.exports.trim = trimPolyfill;
+}
+
+function defined() {
+  return _.find(arguments, _.negate(_.isUndefined));
+}
+
+function trimPolyfill (str) {
+  if (str === null || _.isUndefined(str)) {
+    throw new TypeError("String.prototype.trim called on null or undefined");
+  }
+  return ("" + str).replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+}

--- a/package.json
+++ b/package.json
@@ -10,17 +10,14 @@
   },
   "dependencies": {
     "deep-equal": "~1.0.1",
-    "defined": "~1.0.0",
-    "function-bind": "~1.1.0",
     "glob": "~7.0.0",
-    "has": "~1.0.1",
     "inherits": "~2.0.1",
     "minimist": "~1.2.0",
     "object-inspect": "~1.1.0",
     "resolve": "~1.1.7",
     "resumer": "~0.0.0",
-    "string.prototype.trim": "~1.1.2",
-    "through": "~2.3.8"
+    "through": "~2.3.8",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "concat-stream": "~1.5.1",

--- a/test/array.js
+++ b/test/array.js
@@ -1,7 +1,7 @@
 var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('array test', function (tt) {
     tt.plan(1);

--- a/test/deep.js
+++ b/test/deep.js
@@ -7,3 +7,11 @@ test('deep strict equal', function (t) {
     );
     t.end();
 });
+
+test('deep loose equal', function (t) {
+    t.deepLooseEqual(
+        [ { a: '3' } ],
+        [ { a: 3 } ]
+    );
+    t.end();
+});

--- a/test/end-as-callback.js
+++ b/test/end-as-callback.js
@@ -1,6 +1,6 @@
 var tap = require("tap");
 var tape = require("../");
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test("tape assert.end as callback", function (tt) {
     var test = tape.createHarness({ exit: false })

--- a/test/exit.js
+++ b/test/exit.js
@@ -1,6 +1,6 @@
 var tap = require('tap');
 var spawn = require('child_process').spawn;
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('exit ok', function (t) {
     t.plan(2);

--- a/test/fail.js
+++ b/test/fail.js
@@ -1,7 +1,7 @@
 var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('array test', function (tt) {
     tt.plan(1);

--- a/test/nested-sync-noplan-noend.js
+++ b/test/nested-sync-noplan-noend.js
@@ -1,6 +1,6 @@
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('nested sync test without plan or end', function (tt) {
     tt.plan(1);

--- a/test/nested.js
+++ b/test/nested.js
@@ -1,7 +1,7 @@
 var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('array test', function (tt) {
     tt.plan(1);

--- a/test/only.js
+++ b/test/only.js
@@ -1,6 +1,6 @@
 var tap = require('tap');
 var tape = require('../');
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('tape only test', function (tt) {
     var test = tape.createHarness({ exit: false });

--- a/test/require.js
+++ b/test/require.js
@@ -1,6 +1,6 @@
 var tap = require('tap');
 var spawn = require('child_process').spawn;
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('requiring a single module', function (t) {
     t.plan(2);

--- a/test/timeoutAfter.js
+++ b/test/timeoutAfter.js
@@ -1,6 +1,6 @@
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('timeoutAfter test', function (tt) {
     tt.plan(1);

--- a/test/too_many.js
+++ b/test/too_many.js
@@ -1,7 +1,7 @@
 var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var trim = require('../lib/util').trim;
 
 tap.test('array test', function (tt) {
     tt.plan(1);


### PR DESCRIPTION
I was reading about overuse of tiny packages in Node.js and thought it would be fun to try to reduce the dependencies in tape. Pulling in Underscore.js and adding a util.js for `trim()` and `defined()` removes 10 dependencies, reduces the size of `node_modules` by 500 K, and reduces the install time (`npm install --prod`) by half. The "string.prototype.trim" package is the worst offender, pulling in 9 dependencies when MDN gives a one-liner to implement it. The other packages would be more complicated to remove (without 

`npm ls --prod` before:

    tape@4.5.1 /Users/blong/workspace/tape
    ├── deep-equal@1.0.1
    ├── defined@1.0.0
    ├── function-bind@1.1.0
    ├─┬ glob@7.0.3
    │ ├─┬ inflight@1.0.4
    │ │ └── wrappy@1.0.1
    │ ├─┬ minimatch@3.0.0
    │ │ └─┬ brace-expansion@1.1.3
    │ │   ├── balanced-match@0.3.0
    │ │   └── concat-map@0.0.1
    │ ├── once@1.3.3
    │ └── path-is-absolute@1.0.0
    ├── has@1.0.1
    ├── inherits@2.0.1
    ├── minimist@1.2.0
    ├── object-inspect@1.1.0
    ├── resolve@1.1.7
    ├── resumer@0.0.0
    ├─┬ string.prototype.trim@1.1.2
    │ ├─┬ define-properties@1.1.2
    │ │ ├── foreach@2.0.5
    │ │ └── object-keys@1.0.9
    │ └─┬ es-abstract@1.5.0
    │   ├─┬ es-to-primitive@1.1.1
    │   │ ├── is-date-object@1.0.1
    │   │ └── is-symbol@1.0.1
    │   ├── is-callable@1.1.3
    │   └── is-regex@1.0.3
    └── through@2.3.8

After:

    tape@4.5.1 /Users/blong/workspace/tape
    ├── deep-equal@1.0.1
    ├─┬ glob@7.0.3
    │ ├─┬ inflight@1.0.4
    │ │ └── wrappy@1.0.1
    │ ├─┬ minimatch@3.0.0
    │ │ └─┬ brace-expansion@1.1.3
    │ │   ├── balanced-match@0.3.0
    │ │   └── concat-map@0.0.1
    │ ├── once@1.3.3
    │ └── path-is-absolute@1.0.0
    ├── inherits@2.0.1
    ├── minimist@1.2.0
    ├── object-inspect@1.1.0
    ├── resolve@1.1.7
    ├── resumer@0.0.0
    ├── through@2.3.8
    └── underscore@1.8.3