### PR TITLE
[results] increase object-inspect depth for expected/actual

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -141,8 +141,8 @@ function encodeResult (res, count) {
     output += inner + 'operator: ' + res.operator + '\n';
     
     if (has(res, 'expected') || has(res, 'actual')) {
-        var ex = inspect(res.expected);
-        var ac = inspect(res.actual);
+        var ex = inspect(res.expected, {depth: res.objectPrintDepth});
+        var ac = inspect(res.actual, {depth: res.objectPrintDepth});
         
         if (Math.max(ex.length, ac.length) > 65 || invalidYaml(ex) || invalidYaml(ac)) {
             output += inner + 'expected: |-\n' + inner + '  ' + ex + '\n';

--- a/lib/test.js
+++ b/lib/test.js
@@ -50,6 +50,7 @@ function Test (name_, opts_, cb_) {
     this.pendingCount = 0;
     this._skip = args.opts.skip || false;
     this._timeout = args.opts.timeout;
+    this._objectPrintDepth = args.opts.objectPrintDepth || 5;
     this._plan = undefined;
     this._cb = args.cb;
     this._progeny = [];
@@ -198,7 +199,8 @@ Test.prototype._assert = function assert (ok, opts) {
         ok : Boolean(ok),
         skip : defined(extra.skip, opts.skip),
         name : defined(extra.message, opts.message, '(unnamed assert)'),
-        operator : defined(extra.operator, opts.operator)
+        operator : defined(extra.operator, opts.operator),
+        objectPrintDepth : self._objectPrintDepth
     };
     if (has(opts, 'actual') || has(extra, 'actual')) {
         res.actual = defined(extra.actual, opts.actual);

--- a/readme.markdown
+++ b/readme.markdown
@@ -138,15 +138,17 @@ var test = require('tape')
 
 ## test([name], [opts], cb)
 
-Create a new test with an optional `name` string and optional `opts` object. 
+Create a new test with an optional `name` string and optional `opts` object.
 `cb(t)` fires with the new test object `t` once all preceeding tests have
 finished. Tests execute serially.
 
 Available `opts` options are:
 - opts.skip = true/false. See test.skip.
-- opts.timeout = 500. Set a timeout for the test, after which it will fail. 
+- opts.timeout = 500. Set a timeout for the test, after which it will fail.
   See test.timeoutAfter.
-
+- opts.objectPrintDepth = 5. Configure max depth of expected / actual object
+  printing.
+  
 If you forget to `t.plan()` out how many assertions you are going to run and you
 don't call `t.end()` explicitly, your test will hang.
 

--- a/test/deep-equal-failure.js
+++ b/test/deep-equal-failure.js
@@ -57,6 +57,112 @@ tap.test('deep equal failure', function (assert) {
     });
 })
 
+tap.test('deep equal failure, depth 6, with option', function (assert) {
+    var test = tape.createHarness({ exit : false });
+    var stream = test.createStream();
+    var parser = tapParser();
+    assert.plan(3);
+
+    stream.pipe(parser);
+    stream.pipe(concat(function (body) {
+        assert.equal(
+            body.toString('utf8'),
+            'TAP version 13\n'
+            + '# deep equal\n'
+            + 'not ok 1 should be equal\n'
+            + '  ---\n'
+            + '    operator: equal\n'
+            + '    expected: |-\n'
+            + '      { a: { a1: { a2: { a3: { a4: { a5: 2 } } } } } }\n'
+            + '    actual: |-\n'
+            + '      { a: { a1: { a2: { a3: { a4: { a5: 1 } } } } } }\n'
+            + '  ...\n'
+            + '\n'
+            + '1..1\n'
+            + '# tests 1\n'
+            + '# pass  0\n'
+            + '# fail  1\n'
+        );
+
+        assert.deepEqual(getDiag(body), {
+          operator: 'equal',
+          expected: '{ a: { a1: { a2: { a3: { a4: { a5: 2 } } } } } }',
+          actual: '{ a: { a1: { a2: { a3: { a4: { a5: 1 } } } } } }'
+        });
+    }));
+
+    parser.once('assert', function (data) {
+        assert.deepEqual(data, {
+            ok: false,
+            id: 1,
+            name: 'should be equal',
+            diag: {
+              operator: 'equal',
+              expected: '{ a: { a1: { a2: { a3: { a4: { a5: 2 } } } } } }',
+              actual: '{ a: { a1: { a2: { a3: { a4: { a5: 1 } } } } } }'
+            }
+        });
+    });
+
+    test("deep equal", {objectPrintDepth: 6}, function (t) {
+        t.plan(1);
+        t.equal({ a: { a1: { a2: { a3: { a4: { a5: 1 } } } } } }, { a: { a1: { a2: { a3: { a4: { a5: 2 } } } } } });
+    });
+})
+
+tap.test('deep equal failure, depth 6, without option', function (assert) {
+    var test = tape.createHarness({ exit : false });
+    var stream = test.createStream();
+    var parser = tapParser();
+    assert.plan(3);
+
+    stream.pipe(parser);
+    stream.pipe(concat(function (body) {
+        assert.equal(
+            body.toString('utf8'),
+            'TAP version 13\n'
+            + '# deep equal\n'
+            + 'not ok 1 should be equal\n'
+            + '  ---\n'
+            + '    operator: equal\n'
+            + '    expected: |-\n'
+            + '      { a: { a1: { a2: { a3: { a4: [Object] } } } } }\n'
+            + '    actual: |-\n'
+            + '      { a: { a1: { a2: { a3: { a4: [Object] } } } } }\n'
+            + '  ...\n'
+            + '\n'
+            + '1..1\n'
+            + '# tests 1\n'
+            + '# pass  0\n'
+            + '# fail  1\n'
+        );
+
+        assert.deepEqual(getDiag(body), {
+          operator: 'equal',
+          expected: '{ a: { a1: { a2: { a3: { a4: [Object] } } } } }',
+          actual: '{ a: { a1: { a2: { a3: { a4: [Object] } } } } }'
+        });
+    }));
+
+    parser.once('assert', function (data) {
+        assert.deepEqual(data, {
+            ok: false,
+            id: 1,
+            name: 'should be equal',
+            diag: {
+              operator: 'equal',
+              expected: '{ a: { a1: { a2: { a3: { a4: [Object] } } } } }',
+              actual: '{ a: { a1: { a2: { a3: { a4: [Object] } } } } }'
+            }
+        });
+    });
+
+    test("deep equal", function (t) {
+        t.plan(1);
+        t.equal({ a: { a1: { a2: { a3: { a4: { a5: 1 } } } } } }, { a: { a1: { a2: { a3: { a4: { a5: 2 } } } } } });
+    });
+})
+
 function getDiag (body) {
     var yamlStart = body.indexOf('  ---');
     var yamlEnd = body.indexOf('  ...\n');


### PR DESCRIPTION
It may be best for this to be configurable, but for now 5 seems like
a default that is often too low resulting in confusing output that shows
expected/actual to be identical when the difference is >5 deep.