### PR TITLE
Fix Windows path support in error messages

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -6,6 +6,12 @@ var EventEmitter = require('events').EventEmitter;
 var has = require('has');
 var trim = require('string.prototype.trim');
 
+// regex taken from https://github.com/errwischt/stacktrace-parser/blob/fb58c13ba19dd9aa12b8480d8e9b938524953921/lib/stacktrace-parser.js#L13
+// and edited to:
+// - have a matching group around everything after the 'at'
+// - exclude stracktraces where the location is internal to Node.js (i.e. is only a filename)
+var stacktraceRegexp = new RegExp('^\\s*at ((?:((?:\\[object object\\])?\\S+(?: \\[as \\S+\\])?) )?\\(?(.*?\\' + path.sep + '.*?):(\\d+)(?::(\\d+))?\\)?\\s*)$');
+
 module.exports = Test;
 
 var nextTick = typeof setImmediate !== 'undefined'
@@ -217,36 +223,18 @@ Test.prototype._assert = function assert (ok, opts) {
     if (!ok) {
         var e = new Error('exception');
         var err = (e.stack || '').split('\n');
-        var dir = path.dirname(__dirname) + '/';
+        var dir = path.dirname(__dirname) + path.sep;
         
         for (var i = 0; i < err.length; i++) {
-            var m = /^[^\s]*\s*\bat\s+(.+)/.exec(err[i]);
-            if (!m) {
+            var m = stacktraceRegexp.exec(err[i]);
+            if (!m || m[3].slice(0, dir.length) === dir) {
                 continue;
             }
             
-            var s = m[1].split(/\s+/);
-            var filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
-            if (!filem) {
-                filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[2]);
-                
-                if (!filem) {
-                    filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
-
-                    if (!filem) {
-                        continue;
-                    }
-                }
-            }
-            
-            if (filem[1].slice(0, dir.length) === dir) {
-                continue;
-            }
-            
-            res.functionName = s[0];
-            res.file = filem[1];
-            res.line = Number(filem[2]);
-            if (filem[3]) res.column = filem[3];
+            res.functionName = m[2];
+            res.file = m[3];
+            res.line = Number(m[4]);
+            if (m[5]) res.column = m[5];
             
             res.at = m[1];
             break;


### PR DESCRIPTION
Supersede #221. Fix #220. Generally makes tape support more kinds of stacktrace formats.