### PR TITLE
.only no longer runs all tests having the same name

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,9 +138,10 @@ function createHarness (conf_) {
     var only = false;
     test.only = function (name) {
         if (only) throw new Error('there can only be one only test');
-        results.only(name);
+        var t = test.apply(null, arguments);
+        results.only(t.number);
         only = true;
-        return test.apply(null, arguments);
+        return t;
     };
     test._exitCode = 0;
     

--- a/lib/results.js
+++ b/lib/results.js
@@ -83,8 +83,8 @@ Results.prototype.push = function (t) {
     self.emit('_push', t);
 };
 
-Results.prototype.only = function (name) {
-    this._only = name;
+Results.prototype.only = function (number) {
+    this._only = number;
 };
 
 Results.prototype._watch = function (t) {
@@ -176,7 +176,7 @@ function getNextTest (results) {
     do {
         var t = results.tests.shift();
         if (!t) continue;
-        if (results._only === t.name) {
+        if (results._only === t.number) {
             return t;
         }
     } while (results.tests.length !== 0)

--- a/lib/test.js
+++ b/lib/test.js
@@ -13,6 +13,7 @@ var nextTick = typeof setImmediate !== 'undefined'
     : process.nextTick
 ;
 var safeSetTimeout = setTimeout;
+var nextTestNumber = 1;
 
 inherits(Test, EventEmitter);
 
@@ -44,6 +45,7 @@ function Test (name_, opts_, cb_) {
 
     var args = getTestArgs(name_, opts_, cb_);
 
+    this.number = nextTestNumber++;
     this.readable = true;
     this.name = args.name || '(anonymous)';
     this.assertCount = 0;

--- a/test/only4.js
+++ b/test/only4.js
@@ -1,0 +1,10 @@
+var test = require('../');
+
+test('only4 duplicate test name', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+test.only('only4 duplicate test name', function (t) {
+    t.end();
+});

--- a/test/only5.js
+++ b/test/only5.js
@@ -1,0 +1,10 @@
+var test = require('../');
+
+test.only('only5 duplicate test name', function (t) {
+    t.end();
+});
+
+test('only5 duplicate test name', function (t) {
+    t.fail('not 2');
+    t.end();
+});


### PR DESCRIPTION
This is a fix for #299, wherein all tests having the same name as the test marked `.only` are run.