### PR TITLE
-n option and fix for .only on dup test names

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -6,9 +6,10 @@ var parseOpts = require('minimist');
 var glob = require('glob');
 
 var opts = parseOpts(process.argv.slice(2), {
-        alias: { r: 'require' },
+        alias: { r: 'require', n: 'number' },
         string: 'require',
-        default: { r: [] }
+        boolean: 'n',
+        default: { r: [], n: false }
     });
 
 var cwd = process.cwd();
@@ -24,6 +25,11 @@ opts.require.forEach(function(module) {
       require(resolveModule(module, { basedir: cwd }));
     }
 });
+
+if (opts.number !== false) {
+    var tape = require(resolveModule("tape", { basedir: cwd }));
+    tape.setNumbering(opts.number);
+}
 
 opts._.forEach(function (arg) {
     glob(arg, function (err, files) {

--- a/bin/tape
+++ b/bin/tape
@@ -27,7 +27,13 @@ opts.require.forEach(function(module) {
 });
 
 if (opts.number !== false) {
-    var tape = require(resolveModule("tape", { basedir: cwd }));
+    var tape;
+    try {
+        tape = require(resolveModule("tape", { basedir: cwd }));
+    }
+    catch(err) {
+        tape = require("../"); // assume testing tape module itself
+    }
     tape.setNumbering(opts.number);
 }
 

--- a/index.js
+++ b/index.js
@@ -138,9 +138,10 @@ function createHarness (conf_) {
     var only = false;
     test.only = function (name) {
         if (only) throw new Error('there can only be one only test');
-        results.only(name);
+        var t = test.apply(null, arguments);
+        results.only(t.number);
         only = true;
-        return test.apply(null, arguments);
+        return t;
     };
     test._exitCode = 0;
     

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function createExitHarness (conf) {
             var only = harness._results._only;
             for (var i = 0; i < harness._tests.length; i++) {
                 var t = harness._tests[i];
-                if (only && t.name !== only) continue;
+                if (only && t.number !== only) continue;
                 t._exit();
             }
         }
@@ -107,6 +107,7 @@ function createHarness (conf_) {
     if (conf_.autoclose !== false) {
         results.once('done', function () { results.close() });
     }
+    results.only(onlyTestNumber);
     
     var test = function (name, conf, cb) {
         var t = new Test(name, conf, cb);
@@ -122,8 +123,6 @@ function createHarness (conf_) {
         })(t);
     
         results.push(t);
-        if (t.number === onlyTestNumber)
-            results.only(onlyTestNumber);
             
         return t;
     };
@@ -144,8 +143,9 @@ function createHarness (conf_) {
         if (only) throw new Error('there can only be one only test');
         only = true;
         var t = test.apply(null, arguments);
-        if (!onlyTestNumber)
+        if (!onlyTestNumber) {
             results.only(t.number);
+        }
         return t;
     };
     test._exitCode = 0;
@@ -159,6 +159,7 @@ var onlyTestNumber = false;
 
 function setNumbering (number) {
     Test.showTestNumbers();
-    if (typeof number === "number")
+    if (typeof number === "number") {
         onlyTestNumber = number;
+    }
 }

--- a/lib/results.js
+++ b/lib/results.js
@@ -83,8 +83,8 @@ Results.prototype.push = function (t) {
     self.emit('_push', t);
 };
 
-Results.prototype.only = function (name) {
-    this._only = name;
+Results.prototype.only = function (number) {
+    this._only = number;
 };
 
 Results.prototype._watch = function (t) {
@@ -176,7 +176,7 @@ function getNextTest (results) {
     do {
         var t = results.tests.shift();
         if (!t) continue;
-        if (results._only === t.name) {
+        if (results._only === t.number) {
             return t;
         }
     } while (results.tests.length !== 0)

--- a/lib/results.js
+++ b/lib/results.js
@@ -22,6 +22,7 @@ function Results () {
     this.pass = 0;
     this._stream = through();
     this.tests = [];
+    this._only = null;
 }
 
 Results.prototype.createStream = function (opts) {
@@ -65,6 +66,12 @@ Results.prototype.createStream = function (opts) {
     }
     
     nextTick(function next() {
+        if (self._only !== null) {
+            if (self._only === 0 || self._only > self.tests.length) {
+                console.log("*** test %d not found ***\n", self._only);
+                process.exit(1); // safe. no tests have yet run
+            }
+        }
         var t;
         while (t = getNextTest(self)) {
             t.run();

--- a/lib/test.js
+++ b/lib/test.js
@@ -13,6 +13,7 @@ var nextTick = typeof setImmediate !== 'undefined'
     : process.nextTick
 ;
 var safeSetTimeout = setTimeout;
+var nextTestNumber = 1;
 
 inherits(Test, EventEmitter);
 
@@ -44,6 +45,7 @@ function Test (name_, opts_, cb_) {
 
     var args = getTestArgs(name_, opts_, cb_);
 
+    this.number = nextTestNumber++;
     this.readable = true;
     this.name = args.name || '(anonymous)';
     this.assertCount = 0;

--- a/lib/test.js
+++ b/lib/test.js
@@ -14,6 +14,7 @@ var nextTick = typeof setImmediate !== 'undefined'
 ;
 var safeSetTimeout = setTimeout;
 var nextTestNumber = 1;
+var numbered = false;
 
 inherits(Test, EventEmitter);
 
@@ -48,6 +49,8 @@ function Test (name_, opts_, cb_) {
     this.number = nextTestNumber++;
     this.readable = true;
     this.name = args.name || '(anonymous)';
+    if (numbered)
+        this.name = '['+ this.number +'] '+ this.name;
     this.assertCount = 0;
     this.pendingCount = 0;
     this._skip = args.opts.skip || false;
@@ -499,6 +502,10 @@ Test.skip = function (name_, _opts, _cb) {
     var args = getTestArgs.apply(null, arguments);
     args.opts.skip = true;
     return Test(args.name, args.opts, args.cb);
+};
+
+Test.showTestNumbers = function() {
+    numbered = true;
 };
 
 // vim: set softtabstop=4 shiftwidth=4:

--- a/lib/test.js
+++ b/lib/test.js
@@ -49,8 +49,9 @@ function Test (name_, opts_, cb_) {
     this.number = nextTestNumber++;
     this.readable = true;
     this.name = args.name || '(anonymous)';
-    if (numbered)
+    if (numbered) {
         this.name = '['+ this.number +'] '+ this.name;
+    }
     this.assertCount = 0;
     this.pendingCount = 0;
     this._skip = args.opts.skip || false;
@@ -504,7 +505,7 @@ Test.skip = function (name_, _opts, _cb) {
     return Test(args.name, args.opts, args.cb);
 };
 
-Test.showTestNumbers = function() {
+Test.showTestNumbers = function () {
     numbered = true;
 };
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -70,7 +70,17 @@ There are two ways to run a single test. One way is to modify the test that you 
 
 The `-n` argument runs the tests, prefixing a bracketed test number to the title of each test. For example, if a test named `invalid input` happens to run as the 42nd test of the suite, `-n` will have it display as test `[42] invalid input`. Test numbers may change as tests are added and removed.
 
-The `-nN` argument runs only the Nth test of the test suite, shown as test number N when run with `-n`. The `.only` constraint is ignored when using `-nN`.
+```sh
+$ tape -n tests/**/*.js
+```
+
+The `-nN` argument runs only the Nth test of the test suite, shown as test number N when run with `-n`. For example, this runs the 42nd test:
+
+```sh
+$ tape -n42 tests/**/*.js
+```
+
+The `.only` constraint is ignored when using `-nN`.
 
 ## Preloading modules
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -68,7 +68,7 @@ $ tape "tests/**/*.js"
 
 There are two ways to run a single test. One way is to modify the test that you want to run by adding the `.only` constraint, so that you are calling `test.only("test name", ...)`, as explained [below](#only). The other way is to use the optional `-n` command line argument.
 
-The `-n` argument runs the tests, prefixing a bracketed test number to the title of each test. For example, if a test named `invalid input` happens to run as the 42nd test of the suite, `-n` will have it display as test `[42] invalid input`. Test numbers change as files order changes and as tests are added and removed.
+The `-n` argument runs the tests, prefixing a bracketed test number to the title of each test. For example, if a test named `invalid input` happens to run as the 42nd test of the suite, `-n` will have it display as test `[42] invalid input`. Test numbers change as file order changes and as tests are added and removed.
 
 ```sh
 $ tape -n tests/**/*.js

--- a/readme.markdown
+++ b/readme.markdown
@@ -66,9 +66,9 @@ $ tape "tests/**/*.js"
 
 ## Running a single test
 
-There are two ways to run a single test. One way is to modify the test that you want to run by adding the `.only` constraint, so that you are calling `test.only("test name", ...)`, as explained [below](#only). The other way is via command line.
+There are two ways to run a single test. One way is to modify the test that you want to run by adding the `.only` constraint, so that you are calling `test.only("test name", ...)`, as explained [below](#only). The other way is to use the optional `-n` command line argument.
 
-The `-n` argument runs the tests, prefixing a bracketed test number to the title of each test. For example, if a test named `invalid input` happens to run as the 42nd test of the suite, `-n` will have it display as test `[42] invalid input`. Test numbers may change as tests are added and removed.
+The `-n` argument runs the tests, prefixing a bracketed test number to the title of each test. For example, if a test named `invalid input` happens to run as the 42nd test of the suite, `-n` will have it display as test `[42] invalid input`. Test numbers change as files order changes and as tests are added and removed.
 
 ```sh
 $ tape -n tests/**/*.js

--- a/readme.markdown
+++ b/readme.markdown
@@ -66,7 +66,7 @@ $ tape "tests/**/*.js"
 
 ## Running a single test
 
-There are two ways to run a single test. One way is to modify the test that you want to run by adding the `.only` constraint, so that you are calling `test.only("test name", ...)`, as explaiend [below](#only). The other way is via command line.
+There are two ways to run a single test. One way is to modify the test that you want to run by adding the `.only` constraint, so that you are calling `test.only("test name", ...)`, as explained [below](#only). The other way is via command line.
 
 The `-n` argument runs the tests, prefixing a bracketed test number to the title of each test. For example, if a test named `invalid input` happens to run as the 42nd test of the suite, `-n` will have it display as test `[42] invalid input`. Test numbers may change as tests are added and removed.
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -66,7 +66,7 @@ $ tape "tests/**/*.js"
 
 ## Running a single test
 
-There are two ways to run a single test. One way is to modify the test that you want to run by adding the `.only` constraint, so that you are calling `test.only("test name", ...)` to run the test ([see below](#only)). The other way is via command line.
+There are two ways to run a single test. One way is to modify the test that you want to run by adding the `.only` constraint, so that you are calling `test.only("test name", ...)`, as explaiend [below](#only). The other way is via command line.
 
 The `-n` argument runs the tests, prefixing a bracketed test number to the title of each test. For example, if a test named `invalid input` happens to run as the 42nd test of the suite, `-n` will have it display as test `[42] invalid input`. Test numbers may change as tests are added and removed.
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -64,6 +64,14 @@ $ tape 'tests/**/*.js'
 $ tape "tests/**/*.js"
 ```
 
+## Running a single test
+
+There are two ways to run a single test. One way is to modify the test that you want to run by adding the `.only` constraint, so that you are calling `test.only("test name", ...)` to run the test ([see below](#only)). The other way is via command line.
+
+The `-n` argument runs the tests, prefixing a bracketed test number to the title of each test. For example, if a test named `invalid input` happens to run as the 42nd test of the suite, `-n` will have it display as test `[42] invalid input`. Test numbers may change as tests are added and removed.
+
+The `-nN` argument runs only the Nth test of the test suite, shown as test number N when run with `-n`. The `.only` constraint is ignored when using `-nN`.
+
 ## Preloading modules
 
 Additionally, it is possible to make `tape` load one or more modules before running any tests, by using the `-r` or `--require` flag. Here's an example that loads [babel-register](http://babeljs.io/docs/usage/require/) before running any tests, to allow for JIT compilation:
@@ -286,7 +294,7 @@ By default the TAP output goes to `console.log()`. You can pipe the output to
 someplace else if you `htest.createStream().pipe()` to a destination stream on
 the first tick.
 
-## test.only(name, cb)
+## <a name="only"></a> test.only(name, cb)
 
 Like `test(name, cb)` except if you use `.only` this is the only test case
 that will run for the entire process, all other test cases using tape will

--- a/test/only-number.js
+++ b/test/only-number.js
@@ -1,0 +1,176 @@
+var tap = require('tap');
+var spawn = require('child_process').spawn;
+var trim = require('string.prototype.trim');
+
+tap.test('numbering for -n argument', function (t) {
+    t.plan(2);
+    
+    var tc = tap.createConsumer();
+    
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, [
+            'TAP version 13',
+            '[1] only -n test 1',
+            { id: 1, ok: true, name: 'yes 1' },
+            '[2] only -n test 2',
+            { id: 1, ok: true, name: 'yes 2' },
+            '[3] only -n test 2',
+            { id: 1, ok: true, name: 'yes 3' },
+            'tests 3',
+            'pass  3',
+            'ok'
+        ]);
+    });
+    
+    var ps = tape('-n ./only-number/only-n.js')
+    ps.stdout.pipe(tc);
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});
+
+tap.test('running only X in -nX argument', function (t) {
+    t.plan(2);
+    
+    var tc = tap.createConsumer();
+    
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, expectedResult(2, '[2] only -n2 test 2'));
+    });
+    
+    var ps = tape('-n2 ./only-number/only-n2.js');
+    ps.stdout.pipe(tc);
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});
+
+tap.test('running only -n2 despite .only on test 1', function (t) {
+    t.plan(2);
+    
+    var tc = tap.createConsumer();
+    
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, expectedResult(2, '[2] only -n2 test 2 w/o only'));
+    });
+    
+    var ps = tape('-n2 ./only-number/only1-n2.js');
+    ps.stdout.pipe(tc);
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});
+
+tap.test('running only -n2 also having .only', function (t) {
+    t.plan(2);
+    
+    var tc = tap.createConsumer();
+    
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, expectedResult(2, '[2] only -n2 test 2 w/ only'));
+    });
+    
+    var ps = tape('-n2 ./only-number/only2-n2.js');
+    ps.stdout.pipe(tc);
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});
+
+tap.test('running only -n2 despite .only on test 3', function (t) {
+    t.plan(2);
+    
+    var tc = tap.createConsumer();
+    
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, expectedResult(2, '[2] only -n2 test 2 w/o only'));
+    });
+    
+    var ps = tape('-n2 ./only-number/only3-n2.js');
+    ps.stdout.pipe(tc);
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});
+
+tap.test('running -nX where X is not in 1st file', function (t) {
+    t.plan(2);
+    
+    var tc = tap.createConsumer();
+    
+    var rows = [];
+    tc.on('data', function (r) { rows.push(r) });
+    tc.on('end', function () {
+        var rs = rows.map(function (r) {
+            if (r && typeof r === 'object') {
+                return { id : r.id, ok : r.ok, name : trim(r.name) };
+            }
+            else return r;
+        });
+        t.same(rs, expectedResult(5, '[5] multi2 test 2'));
+    });
+    
+    var ps = tape('-n5 ./only-number/multi1-n5.js ./only-number/multi2-n5.js');
+    ps.stdout.pipe(tc);
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});
+
+function tape(args) {
+  var proc = require('child_process')
+  var bin = __dirname + '/../bin/tape'
+
+  return proc.spawn(bin, args.split(' '), { cwd: __dirname })
+}
+
+function expectedResult(id, testName) {
+    return [
+        'TAP version 13',
+        testName,
+        { id: id, ok: true, name: 'yes 2' },
+        'tests 1',
+        'pass  1',
+        'ok'
+    ];
+}

--- a/test/only-number.js
+++ b/test/only-number.js
@@ -21,16 +21,16 @@ tap.test('numbering for -n argument', function (t) {
             '[1] only -n test 1',
             { id: 1, ok: true, name: 'yes 1' },
             '[2] only -n test 2',
-            { id: 1, ok: true, name: 'yes 2' },
-            '[3] only -n test 2',
-            { id: 1, ok: true, name: 'yes 3' },
+            { id: 2, ok: true, name: 'yes 2' },
+            '[3] only -n test 3',
+            { id: 3, ok: true, name: 'yes 3' },
             'tests 3',
             'pass  3',
             'ok'
         ]);
     });
     
-    var ps = tape('-n ./only-number/only-n.js')
+    var ps = tape('-n only-number/only-n.js')
     ps.stdout.pipe(tc);
     ps.on('exit', function (code) {
         t.equal(code, 0);
@@ -51,10 +51,10 @@ tap.test('running only X in -nX argument', function (t) {
             }
             else return r;
         });
-        t.same(rs, expectedResult(2, '[2] only -n2 test 2'));
+        t.same(rs, expectedResult('[2] only -n2 test 2'));
     });
     
-    var ps = tape('-n2 ./only-number/only-n2.js');
+    var ps = tape('-n2 only-number/only-n2.js');
     ps.stdout.pipe(tc);
     ps.on('exit', function (code) {
         t.equal(code, 0);
@@ -75,10 +75,10 @@ tap.test('running only -n2 despite .only on test 1', function (t) {
             }
             else return r;
         });
-        t.same(rs, expectedResult(2, '[2] only -n2 test 2 w/o only'));
+        t.same(rs, expectedResult('[2] only -n2 test 2 w/o only'));
     });
     
-    var ps = tape('-n2 ./only-number/only1-n2.js');
+    var ps = tape('-n2 only-number/only1-n2.js');
     ps.stdout.pipe(tc);
     ps.on('exit', function (code) {
         t.equal(code, 0);
@@ -99,10 +99,10 @@ tap.test('running only -n2 also having .only', function (t) {
             }
             else return r;
         });
-        t.same(rs, expectedResult(2, '[2] only -n2 test 2 w/ only'));
+        t.same(rs, expectedResult('[2] only -n2 test 2 w/ only'));
     });
     
-    var ps = tape('-n2 ./only-number/only2-n2.js');
+    var ps = tape('-n2 only-number/only2-n2.js');
     ps.stdout.pipe(tc);
     ps.on('exit', function (code) {
         t.equal(code, 0);
@@ -123,10 +123,10 @@ tap.test('running only -n2 despite .only on test 3', function (t) {
             }
             else return r;
         });
-        t.same(rs, expectedResult(2, '[2] only -n2 test 2 w/o only'));
+        t.same(rs, expectedResult('[2] only -n2 test 2 w/o only'));
     });
     
-    var ps = tape('-n2 ./only-number/only3-n2.js');
+    var ps = tape('-n2 only-number/only3-n2.js');
     ps.stdout.pipe(tc);
     ps.on('exit', function (code) {
         t.equal(code, 0);
@@ -147,10 +147,10 @@ tap.test('running -nX where X is not in 1st file', function (t) {
             }
             else return r;
         });
-        t.same(rs, expectedResult(5, '[5] multi2 test 2'));
+        t.same(rs, expectedResult('[5] multi2 test 2'));
     });
     
-    var ps = tape('-n5 ./only-number/multi1-n5.js ./only-number/multi2-n5.js');
+    var ps = tape('-n5 only-number/multi1-n5.js only-number/multi2-n5.js');
     ps.stdout.pipe(tc);
     ps.on('exit', function (code) {
         t.equal(code, 0);
@@ -164,11 +164,11 @@ function tape(args) {
   return proc.spawn(bin, args.split(' '), { cwd: __dirname })
 }
 
-function expectedResult(id, testName) {
+function expectedResult(testName) {
     return [
         'TAP version 13',
         testName,
-        { id: id, ok: true, name: 'yes 2' },
+        { id: 1, ok: true, name: 'yes 2' },
         'tests 1',
         'pass  1',
         'ok'

--- a/test/only-number/multi1-n5.js
+++ b/test/only-number/multi1-n5.js
@@ -1,0 +1,16 @@
+var tape = require('../..');
+
+tape('multi1 test 1', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+tape('multi1 test 2', function (t) {
+    t.fail('not 2');
+    t.end();
+});
+
+tape('multi1 test 3', function (t) {
+    t.fail('not 3');
+    t.end();
+});

--- a/test/only-number/multi2-n5.js
+++ b/test/only-number/multi2-n5.js
@@ -1,0 +1,16 @@
+var tape = require('../..');
+
+tape('multi2 test 1', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+tape('multi2 test 2', function (t) {
+    t.pass('yes 2');
+    t.end();
+});
+
+tape('multi2 test 3', function (t) {
+    t.fail('not 3');
+    t.end();
+});

--- a/test/only-number/only-n.js
+++ b/test/only-number/only-n.js
@@ -1,0 +1,16 @@
+var tape = require('../..');
+
+tape('only -n test 1', function (t) {
+    t.pass('yes 1');
+    t.end();
+});
+
+tape('only -n test 2', function (t) {
+    t.pass('yes 2');
+    t.end();
+});
+
+tape('only -n test 3', function (t) {
+    t.pass('yes 3');
+    t.end();
+});

--- a/test/only-number/only-n2.js
+++ b/test/only-number/only-n2.js
@@ -1,0 +1,16 @@
+var tape = require('../..');
+
+tape('only -n2 test 1', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+tape('only -n2 test 2', function (t) {
+    t.pass('yes 2');
+    t.end();
+});
+
+tape('only -n2 test 3', function (t) {
+    t.fail('not 3');
+    t.end();
+});

--- a/test/only-number/only1-n2.js
+++ b/test/only-number/only1-n2.js
@@ -1,0 +1,16 @@
+var tape = require('../..');
+
+tape.only('only -n2 test 1 w/ only', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+tape('only -n2 test 2 w/o only', function (t) {
+    t.pass('yes 2');
+    t.end();
+});
+
+tape('only -n2 test 3 w/o only', function (t) {
+    t.fail('not 3');
+    t.end();
+});

--- a/test/only-number/only2-n2.js
+++ b/test/only-number/only2-n2.js
@@ -1,0 +1,16 @@
+var tape = require('../..');
+
+tape('only -n2 test 1 w/o only', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+tape.only('only -n2 test 2 w/ only', function (t) {
+    t.pass('yes 2');
+    t.end();
+});
+
+tape('only -n2 test 3 w/o only', function (t) {
+    t.fail('not 3');
+    t.end();
+});

--- a/test/only-number/only3-n2.js
+++ b/test/only-number/only3-n2.js
@@ -1,0 +1,16 @@
+var tape = require('../..');
+
+tape('only -n2 test 1 w/o only', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+tape('only -n2 test 2 w/o only', function (t) {
+    t.pass('yes 2');
+    t.end();
+});
+
+tape.only('only -n2 test 3 w/ only', function (t) {
+    t.fail('not 3');
+    t.end();
+});

--- a/test/only4.js
+++ b/test/only4.js
@@ -1,0 +1,10 @@
+var test = require('../');
+
+test('only4 duplicate test name', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+test.only('only4 duplicate test name', function (t) {
+    t.end();
+});

--- a/test/only5.js
+++ b/test/only5.js
@@ -1,0 +1,10 @@
+var test = require('../');
+
+test.only('only5 duplicate test name', function (t) {
+    t.end();
+});
+
+test('only5 duplicate test name', function (t) {
+    t.fail('not 2');
+    t.end();
+});


### PR DESCRIPTION
This PR provides the `-n` option described in #301 and the fix for #299 on which it depends.