### PR TITLE
reference-based .only fix for #299

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function createExitHarness (conf) {
             var only = harness._results._only;
             for (var i = 0; i < harness._tests.length; i++) {
                 var t = harness._tests[i];
-                if (only && t.name !== only) continue;
+                if (only && t !== only) continue;
                 t._exit();
             }
         }
@@ -136,11 +136,12 @@ function createHarness (conf_) {
     };
     
     var only = false;
-    test.only = function (name) {
+    test.only = function () {
         if (only) throw new Error('there can only be one only test');
-        results.only(name);
         only = true;
-        return test.apply(null, arguments);
+        t = test.apply(null, arguments);
+        results.only(t);
+        return t;
     };
     test._exitCode = 0;
     

--- a/lib/results.js
+++ b/lib/results.js
@@ -22,7 +22,7 @@ function Results () {
     this.pass = 0;
     this._stream = through();
     this.tests = [];
-    this._only = 0;
+    this._only = null;
 }
 
 Results.prototype.createStream = function (opts) {

--- a/lib/results.js
+++ b/lib/results.js
@@ -22,6 +22,7 @@ function Results () {
     this.pass = 0;
     this._stream = through();
     this.tests = [];
+    this._only = 0;
 }
 
 Results.prototype.createStream = function (opts) {
@@ -83,8 +84,8 @@ Results.prototype.push = function (t) {
     self.emit('_push', t);
 };
 
-Results.prototype.only = function (name) {
-    this._only = name;
+Results.prototype.only = function (t) {
+    this._only = t;
 };
 
 Results.prototype._watch = function (t) {
@@ -176,7 +177,7 @@ function getNextTest (results) {
     do {
         var t = results.tests.shift();
         if (!t) continue;
-        if (results._only === t.name) {
+        if (results._only === t) {
             return t;
         }
     } while (results.tests.length !== 0)

--- a/test/only4.js
+++ b/test/only4.js
@@ -1,0 +1,10 @@
+var test = require('../');
+
+test('only4 duplicate test name', function (t) {
+    t.fail('not 1');
+    t.end();
+});
+
+test.only('only4 duplicate test name', function (t) {
+    t.end();
+});

--- a/test/only5.js
+++ b/test/only5.js
@@ -1,0 +1,10 @@
+var test = require('../');
+
+test.only('only5 duplicate test name', function (t) {
+    t.end();
+});
+
+test('only5 duplicate test name', function (t) {
+    t.fail('not 2');
+    t.end();
+});


### PR DESCRIPTION
.only now identifies tests by reference instead of by test name, fixing #299