### PR TITLE
Pre- and post-processing hooks, plus abort/bail-out

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,18 @@ exports = module.exports = (function () {
         return harness.createStream(opts);
     };
     
+    lazyLoad.abort = function () {
+        return getHarness().abort.apply(this, arguments);
+    };
+    
+    lazyLoad.onStart = function () {
+        return getHarness().onStart.apply(this, arguments);
+    };
+
+    lazyLoad.onTest = function () {
+        return getHarness().onTest.apply(this, arguments);
+    };
+
     lazyLoad.onFinish = function () {
         return getHarness().onFinish.apply(this, arguments);
     };
@@ -80,8 +92,9 @@ function createExitHarness (conf) {
 
         if (!ended) {
             var only = harness._results._only;
-            for (var i = 0; i < harness._tests.length; i++) {
-                var t = harness._tests[i];
+            var awaitTests = harness._results.awaitTests;
+            for (var i = 0; i < harness._results._ran; i++) {
+                var t = awaitTests[i];
                 if (only && t !== only) continue;
                 t._exit();
             }
@@ -109,7 +122,6 @@ function createHarness (conf_) {
     
     var test = function (name, conf, cb) {
         var t = new Test(name, conf, cb);
-        test._tests.push(t);
         
         (function inspectCode (st) {
             st.on('test', function sub (st_) {
@@ -125,12 +137,22 @@ function createHarness (conf_) {
     };
     test._results = results;
     
-    test._tests = [];
-    
     test.createStream = function (opts) {
         return results.createStream(opts);
     };
+    
+    test.abort = function (msg) {
+        results.bailout = msg || "Aborted by test suite";
+    };
 
+    test.onStart = function (cb) {
+        results.on('prep', cb);
+    };
+    
+    test.onTest = function (cb) {
+        results.on('test', cb);
+    };
+    
     test.onFinish = function (cb) {
         results.on('done', cb);
     };
@@ -139,7 +161,7 @@ function createHarness (conf_) {
     test.only = function () {
         if (only) throw new Error('there can only be one only test');
         only = true;
-        t = test.apply(null, arguments);
+        var t = test.apply(null, arguments);
         results.only(t);
         return t;
     };

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function createExitHarness (conf) {
         if (!ended) {
             var only = harness._results._only;
             var awaitTests = harness._results.awaitTests;
-            for (var i = 0; i < harness._results._ran; i++) {
+            for (var i = 0; i < harness._results._runCount; i++) {
                 var t = awaitTests[i];
                 if (only && t !== only) continue;
                 t._exit();

--- a/lib/results.js
+++ b/lib/results.js
@@ -23,6 +23,8 @@ function Results () {
     this._stream = through();
     this.tests = [];
     this._only = null;
+    this._ran = 0;
+    this.bailout = null;
 }
 
 Results.prototype.createStream = function (opts) {
@@ -65,13 +67,20 @@ Results.prototype.createStream = function (opts) {
         self._stream.pipe(output);
     }
     
-    nextTick(function next() {
-        var t;
-        while (t = getNextTest(self)) {
-            t.run();
-            if (!t.ended) return t.once('end', function(){ nextTick(next); });
-        }
-        self.emit('done');
+    nextTick(function prep() {
+        self.emit('prep', self.tests);
+        self.awaitTests = self.tests.slice(0);
+        (function next() {
+            var t;
+            while (self.bailout === null && (t = getNextTest(self))) {
+                self._ran ++;
+                t.run();
+                if (!t.ended) {
+                    return t.once('end', function () { nextTick(next); });
+                }
+            }
+            self.emit('done');
+        })();
     });
     
     return output;
@@ -108,6 +117,8 @@ Results.prototype._watch = function (t) {
     });
     
     t.on('test', function (st) { self._watch(st) });
+
+    t.on('end', function () { self.emit('test', t); });
 };
 
 Results.prototype.close = function () {
@@ -120,7 +131,9 @@ Results.prototype.close = function () {
     write('# tests ' + self.count + '\n');
     write('# pass  ' + self.pass + '\n');
     if (self.fail) write('# fail  ' + self.fail + '\n')
-    else write('\n# ok\n')
+    else if (self.bailout === null) write('\n# ok\n')
+    
+    if (self.bailout !== null) write('\nBail out! ' + self.bailout + '\n')
 
     self._stream.queue(null);
 };

--- a/lib/results.js
+++ b/lib/results.js
@@ -23,7 +23,7 @@ function Results () {
     this._stream = through();
     this.tests = [];
     this._only = null;
-    this._ran = 0;
+    this._runCount = 0;
     this.bailout = null;
 }
 
@@ -73,7 +73,7 @@ Results.prototype.createStream = function (opts) {
         (function next() {
             var t;
             while (self.bailout === null && (t = getNextTest(self))) {
-                self._ran ++;
+                self._runCount ++;
                 t.run();
                 if (!t.ended) {
                     return t.once('end', function () { nextTick(next); });

--- a/lib/test.js
+++ b/lib/test.js
@@ -47,6 +47,7 @@ function Test (name_, opts_, cb_) {
     this.readable = true;
     this.name = args.name || '(anonymous)';
     this.assertCount = 0;
+    this.failCount = 0;
     this.pendingCount = 0;
     this._skip = args.opts.skip || false;
     this._timeout = args.opts.timeout;
@@ -212,6 +213,7 @@ Test.prototype._assert = function assert (ok, opts) {
     
     if (!ok) {
         res.error = defined(extra.error, opts.error, new Error(res.name));
+        self.failCount ++;
     }
     
     if (!ok) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -158,11 +158,11 @@ Generate a new test that will be skipped over.
 
 ## test.onStart(fn)
 
-The onStart hook is called before any tape tests have begun running. The callback `fn` is passed an array of test objects. onStart may rename tests via the `t.name` attribute, remove tests from the array, or otherwise validate the tests before allowing the tests to run. The callback may not employ the methods that are available to the test during its run.
+The onStart hook is called before any tape tests have begun running. The callback `fn` is passed an array of test objects. onStart may rename tests via the `t.name` attribute, remove tests from the array, or otherwise validate the tests before allowing the tests to run. The callback may not employ the methods that are available to the test during its run, except for `test.abort()`.
 
 ## test.onTest(fn)
 
-The onTest hook is called after a test completes. A test completes when `t.end()` is called or the test has reached the planned assertion count. The callback `fn` is passed a reference to the test object that just completed. The callback may examine the test object for `t.name`, `t.assertCount`, and `t.failCount`. `assertCount` is the number of assertions in the test, and `failCount` is the number of assertions that failed. `t.comment()` is also available. 
+The onTest hook is called after a test completes. A test completes when `t.end()` is called or the test has reached the planned assertion count. The callback `fn` is passed a reference to the test object that just completed. The callback may examine the test object for `t.name`, `t.assertCount`, and `t.failCount`. `assertCount` is the number of assertions in the test, and `failCount` is the number of assertions that failed. `t.comment()` and `test.abort()` are also available.
 
 ## test.onFinish(fn)
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -162,7 +162,7 @@ The onStart hook is called before any tape tests have begun running. The callbac
 
 ## test.onTest(fn)
 
-The onTest hook is called after each test completes. A test completes when `t.end()` is called or the test has reached the planned assertion count. The callback `fn` is passed a reference to the test object that just completed. The callback may examine the test object for `t.name`, `t.assertCount`, and `t.failCount`. `assertCount` is the number of assertions in the test, and `failCount` is the number of assertions that failed. `t.comment()` is also available. 
+The onTest hook is called after a test completes. A test completes when `t.end()` is called or the test has reached the planned assertion count. The callback `fn` is passed a reference to the test object that just completed. The callback may examine the test object for `t.name`, `t.assertCount`, and `t.failCount`. `assertCount` is the number of assertions in the test, and `failCount` is the number of assertions that failed. `t.comment()` is also available. 
 
 ## test.onFinish(fn)
 
@@ -171,7 +171,7 @@ right before tape is about to print the test summary.
 
 ## test.abort(msg)
 
-The `abort` method halts testing. Calling it results the output of a summary of all tests that did run, followed by a TAP "Bail out!" notice line. The provided `msg` is tacked onto the notice line to indicate the reason for the abort. This method may be called at any time during testing, including within the onTest hook.
+The `abort` method halts testing after the current test. Calling it results the output of a summary of all tests that did run, followed by a TAP "Bail out!" notice line. The provided `msg` is tacked onto the notice line to indicate the reason for the abort. This method may be called at any time during testing, including within the onTest hook.
 
 ## t.plan(n)
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -156,10 +156,22 @@ don't call `t.end()` explicitly, your test will hang.
 
 Generate a new test that will be skipped over.
 
+## test.onStart(fn)
+
+The onStart hook is called before any tape tests have begun running. The callback `fn` is passed an array of test objects. onStart may rename tests via the `t.name` attribute, remove tests from the array, or otherwise validate the tests before allowing the tests to run. The callback may not employ the methods that are available to the test during its run.
+
+## test.onTest(fn)
+
+The onTest hook is called after each test completes. A test completes when `t.end()` is called or the test has reached the planned assertion count. The callback `fn` is passed a reference to the test object that just completed. The callback may examine the test object for `t.name`, `t.assertCount`, and `t.failCount`. `assertCount` is the number of assertions in the test, and `failCount` is the number of assertions that failed. `t.comment()` is also available. 
+
 ## test.onFinish(fn)
 
 The onFinish hook will get invoked when ALL tape tests have finished
 right before tape is about to print the test summary.
+
+## test.abort(msg)
+
+The `abort` method halts testing. Calling it results the output of a summary of all tests that did run, followed by a TAP "Bail out!" notice line. The provided `msg` is tacked onto the notice line to indicate the reason for the abort. This method may be called at any time during testing, including within the onTest hook.
 
 ## t.plan(n)
 

--- a/test/abort.js
+++ b/test/abort.js
@@ -9,7 +9,6 @@ tap.test('test abort onStart', function (assert) {
     var verify = function (output) {
         assert.equal(output.toString('utf8'), [
             'TAP version 13',
-            
             '',
             '1..0',
             '# tests 0',

--- a/test/abort.js
+++ b/test/abort.js
@@ -1,0 +1,81 @@
+var test = require('../');
+
+var concat = require('concat-stream');
+var tap = require('tap');
+
+tap.test('test abort onStart', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            
+            '',
+            '1..0',
+            '# tests 0',
+            '# pass  0',
+            '',
+            'Bail out! Invalid test environment',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    tapeTest.onStart(function (tests) {
+        tapeTest.abort('Invalid test environment');
+    });
+
+    tapeTest.createStream().pipe(concat(verify));
+    
+    tapeTest('first test', function (t) {
+        t.pass("assertion 1");
+        t.end();
+    });
+    
+    tapeTest('second test', function (t) {
+        t.pass("assertion 2");
+        t.end();
+    });
+});
+
+tap.test('test abort from test', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            '# first test',
+            'ok 1 assertion 1',
+            '# second test',
+            'ok 2 assertion 2',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  2',
+            '',
+           'Bail out! Aborted by test suite',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    tapeTest.createStream().pipe(concat(verify));
+    
+    tapeTest('first test', function (t) {
+        t.pass("assertion 1");
+        t.end();
+    });
+    
+    tapeTest('second test', function (t) {
+        tapeTest.abort(); // use default message
+        t.pass("assertion 2");
+        t.end();
+    });
+
+    tapeTest('third test', function (t) {
+        t.pass("assertion 3");
+        t.end();
+    });
+});
+
+// the test of aborting from onTest() is in onTest.js

--- a/test/onStart.js
+++ b/test/onStart.js
@@ -1,0 +1,103 @@
+var test = require('../');
+
+var concat = require('concat-stream');
+var tap = require('tap');
+
+tap.test('test onStart renaming', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            '# [1] first test',
+            'ok 1 assertion 1',
+            '# SKIP [2] second test',
+            '# [3] third test',
+            'ok 2 assertion 3',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  2',
+            '',
+            '# ok',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    tapeTest.onStart(function (tests) {
+        for (var i=0; i < tests.length; ++i) {
+            tests[i].name = '[' + (i+1) + '] ' + tests[i].name;
+        }
+    });
+
+    tapeTest.createStream().pipe(concat(verify));
+    
+    tapeTest('first test', function (t) {
+        t.pass("assertion 1");
+        t.end();
+    });
+    
+    tapeTest('second test', { skip: true }, function (t) {
+        t.fail("assertion 2");
+        t.end();
+    });
+
+    tapeTest('third test', function (t) {
+        t.pass("assertion 3");
+        t.end();
+    });
+});
+
+tap.test('test onStart filtering', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            '# first test',
+            'ok 1 assertion 1',
+            '# third test',
+            'ok 2 assertion 3',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  2',
+            '',
+            '# ok',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    tapeTest.onStart(function (tests) {
+        var i = tests.length;
+        while (--i >= 0) {
+            if (/[+]deprecated/.test(tests[i].name)) {
+                tests.splice(i, 1);
+            }
+        }
+    });
+    
+    tapeTest.createStream().pipe(concat(verify));
+    
+    tapeTest('first test', function (t) {
+        t.pass("assertion 1");
+        t.end();
+    });
+    
+    tapeTest('second test +deprecated', function (t) {
+        t.fail("assertion 2");
+        t.end();
+    });
+
+    tapeTest('third test', function (t) {
+        t.pass("assertion 3");
+        t.end();
+    });
+
+    tapeTest('fourth test +deprecated', function (t) {
+        t.fail("assertion 4");
+        t.end();
+    });
+});

--- a/test/onTest.js
+++ b/test/onTest.js
@@ -1,0 +1,168 @@
+var test = require('../');
+
+var concat = require('concat-stream');
+var tap = require('tap');
+
+tap.test('onTest abort', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            '# first test',
+            'ok 1 assertion 1',
+            '# second test',
+            'not ok 2 assertion 2',
+            '  ---',
+            '    operator: fail',
+            '  ...',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  1',
+            '# fail  1',
+            '',
+            'Bail out! Aborting on first failed test',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    tapeTest.onTest(function (t) {
+        if (t.failCount > 0) {
+            tapeTest.abort("Aborting on first failed test");
+        }
+    });
+    
+    tapeTest.createStream().pipe(concat(verify));
+    
+    tapeTest('first test', function (t) {
+        t.pass("assertion 1");
+        t.end();
+    });
+    
+    tapeTest('second test', function (t) {
+        t.fail("assertion 2");
+        t.end();
+    });
+
+    tapeTest('third test', function (t) {
+        t.pass("assertion 3");
+        t.end();
+    });
+});
+
+tap.test('onTest cleanup', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            '# first test',
+            'ok 1 assertion 1',
+            '# second test',
+            'ok 2 assertion 2',
+            'ok 3 assertion 3',
+            '# third test',
+            'ok 4 assertion 4',
+            '',
+            '1..4',
+            '# tests 4',
+            '# pass  4',
+            '',
+            '# ok',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    var externalData = [];
+    tapeTest.onTest(function (t) {
+        externalData = [];
+    });
+    
+    tapeTest.createStream().pipe(concat(verify));
+    
+    tapeTest('first test', function (t) {
+        externalData.push("x");
+        t.equal(externalData.length, 1, "assertion 1");
+        t.end();
+    });
+    
+    tapeTest('second test', function (t) {
+        externalData.push("x");
+        t.equal(externalData.length, 1, "assertion 2");
+        externalData.push("y");
+        t.equal(externalData.length, 2, "assertion 3");
+        t.end();
+    });
+
+    tapeTest('third test', function (t) {
+        externalData.push("z");
+        t.equal(externalData.length, 1, "assertion 4");
+        t.end();
+    });
+});
+
+tap.test('onTest comment', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            '# first test',
+            'ok 1 assertion 1',
+            'ok 2 assertion 2',
+            '# (2 passed, 0 failed)',
+            '# second test',
+            'ok 3 assertion 3',
+            'not ok 4 assertion 4',
+            '  ---',
+            '    operator: fail',
+            '  ...',
+            '# (1 passed, 1 failed)',
+            '# third test',
+            'not ok 5 assertion 5',
+            '  ---',
+            '    operator: fail',
+            '  ...',
+            'not ok 6 assertion 6',
+            '  ---',
+            '    operator: fail',
+            '  ...',
+            '# (0 passed, 2 failed)',
+            '',
+            '1..6',
+            '# tests 6',
+            '# pass  3',
+            '# fail  3',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    tapeTest.onTest(function (t) {
+        var passCount = t.assertCount - t.failCount;
+        t.comment("(" + passCount + " passed, " + t.failCount + " failed)");
+    });
+    
+    tapeTest.createStream().pipe(concat(verify));
+    
+    tapeTest('first test', function (t) {
+        t.pass("assertion 1");
+        t.pass("assertion 2");
+        t.end();
+    });
+    
+    tapeTest('second test', function (t) {
+        t.pass("assertion 3");
+        t.fail("assertion 4");
+        t.end();
+    });
+
+    tapeTest('third test', function (t) {
+        t.fail("assertion 5");
+        t.fail("assertion 6");
+        t.end();
+    });
+});


### PR DESCRIPTION
These are the simplest modifications I can find for allowing me to hook in the features I need for [`tapeo`](https://www.npmjs.com/package/tapeo). See #304 