### PR TITLE
Fix for not showing path for error messages on windows

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -217,7 +217,7 @@ Test.prototype._assert = function assert (ok, opts) {
     if (!ok) {
         var e = new Error('exception');
         var err = (e.stack || '').split('\n');
-        var dir = path.dirname(__dirname) + '/';
+        var dir = path.dirname(__dirname) + path.sep;
         
         for (var i = 0; i < err.length; i++) {
             var m = /^[^\s]*\s*\bat\s+(.+)/.exec(err[i]);
@@ -226,12 +226,12 @@ Test.prototype._assert = function assert (ok, opts) {
             }
             
             var s = m[1].split(/\s+/);
-            var filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
+            var filem = /((?:\/|[A-Z]:\\)[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[1]);
             if (!filem) {
-                filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[2]);
+                filem = /((?:\/|[A-Z]:\\)[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[2]);
                 
                 if (!filem) {
-                    filem = /(\/[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
+                    filem = /((?:\/|[A-Z]:\\)[^:\s]+:(\d+)(?::(\d+))?)/.exec(s[3]);
 
                     if (!filem) {
                         continue;

--- a/test/require.js
+++ b/test/require.js
@@ -65,5 +65,5 @@ function tape(args) {
   var proc = require('child_process')
   var bin = __dirname + '/../bin/tape'
 
-  return proc.spawn(bin, args.split(' '), { cwd: __dirname })
+  return proc.spawn('node', [bin].concat(args.split(' ')), { cwd: __dirname })
 }

--- a/test/require/a.js
+++ b/test/require/a.js
@@ -1,8 +1,8 @@
 var tape = require('../..');
 
 tape.test('module-a', function(t) {
+  t.plan(1)
   t.pass('loaded module a')
-  t.end()
 })
 
 global.module_a = true

--- a/test/require/b.js
+++ b/test/require/b.js
@@ -1,8 +1,8 @@
 var tape = require('../..');
 
 tape.test('module-b', function(t) {
+  t.plan(1)
   t.pass('loaded module b')
-  t.end()
 })
 
 global.module_b = true


### PR DESCRIPTION
This bug has been around for a while now, there are two open PR's (#221 and #295) but no activity recently.
This is basically the solution proposed by @hgwood.
Tried to keep changes to the bare minimum.