### PR TITLE
Update to latest version of devDependencies tap (v7) and tap-parser (v2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "concat-stream": "~1.5.1",
     "falafel": "~1.2.0",
     "js-yaml": "~3.6.1",
-    "tap": "~0.7.1",
-    "tap-parser": "~1.2.2"
+    "tap": "~7.0.0",
+    "tap-parser": "~2.0.0"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/readme.markdown
+++ b/readme.markdown
@@ -88,7 +88,7 @@ Please note that all modules loaded using the `-r` flag will run *before* any te
 
 tape maintains a fairly minimal core. Additional features are usually added by using another module alongside tape.
 
-## reporters for humans
+## pretty reporters
 
 The default TAP output is good for machines and humans that are robots.
 
@@ -98,30 +98,26 @@ that will output something pretty if you pipe TAP into them:
  - https://github.com/scottcorgan/tap-spec
  - https://github.com/scottcorgan/tap-dot
  - https://github.com/substack/faucet
+ - https://github.com/juliangruber/tap-bail
  - https://github.com/kirbysayshi/tap-browser-color
+ - https://github.com/gummesson/tap-json
  - https://github.com/gummesson/tap-min
  - https://github.com/calvinmetcalf/tap-nyan
- - https://github.com/clux/tap-pessimist
+ - https://www.npmjs.org/package/tap-pessimist
  - https://github.com/toolness/tap-prettify
  - https://github.com/shuhei/colortape
+ - https://github.com/aghassemi/tap-xunit
  - https://github.com/namuol/tap-difflet
+ - https://github.com/gritzko/tape-dom
  - https://github.com/axross/tap-diff
  - https://github.com/axross/tap-notify
  - https://github.com/zoubin/tap-summary
- 
-You use these reporters by piping the tape output into them. For example,
-try `node test/index.js | tap-spec`.
-
-## reporters for other file formats
-
- - https://github.com/gummesson/tap-json
- - https://github.com/aghassemi/tap-xunit
- - https://github.com/gritzko/tape-dom
  - https://github.com/Hypercubed/tap-markdown
 
-## failing assertions
+To use them, try `node test/index.js | tap-spec` or pipe it into one
+of the modules of your choice!
 
-If any assertions fail, tape will continue. To terminate on the first failure, see [tap-bail](https://github.com/juliangruber/tap-bail).
+## uncaught exceptions
 
 By default, uncaught exceptions in your tests will not be intercepted, and will cause tape to crash. If you find this behavior undesirable, use [tape-catch](https://github.com/michaelrhodes/tape-catch) to report any exceptions as TAP errors.
 
@@ -130,7 +126,6 @@ By default, uncaught exceptions in your tests will not be intercepted, and will 
 - CoffeeScript support with https://www.npmjs.com/package/coffeetape
 - Promise support with https://www.npmjs.com/package/blue-tape
 - ES6 support with https://www.npmjs.com/package/babel-tape-runner
-- Inclue time information with https://github.com/diasdavid/timed-tape
 
 # methods
 

--- a/test/array.js
+++ b/test/array.js
@@ -5,9 +5,9 @@ var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
     tt.plan(1);
-
+    
     var test = tape.createHarness();
-
+    
     test.createStream().pipe(concat(function (rows) {
         tt.same(rows.toString('utf8'), [
             'TAP version 13',
@@ -25,29 +25,29 @@ tap.test('array test', function (tt) {
             '# ok'
         ].join('\n') + '\n');
     }));
-
+    
     test('array', function (t) {
         t.plan(5);
-
+        
         var src = '(' + function () {
             var xs = [ 1, 2, [ 3, 4 ] ];
             var ys = [ 5, 6 ];
             g([ xs, ys ]);
         } + ')()';
-
+        
         var output = falafel(src, function (node) {
             if (node.type === 'ArrayExpression') {
                 node.update('fn(' + node.source() + ')');
             }
         });
-
+        
         var arrays = [
             [ 3, 4 ],
             [ 1, 2, [ 3, 4 ] ],
             [ 5, 6 ],
             [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
         ];
-
+        
         Function(['fn','g'], output)(
             function (xs) {
                 t.same(arrays.shift(), xs);

--- a/test/array.js
+++ b/test/array.js
@@ -1,61 +1,53 @@
 var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
     tt.plan(1);
-    
+
     var test = tape.createHarness();
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        tt.same(rs, [
+
+    test.createStream().pipe(concat(function (rows) {
+        tt.same(rows.toString('utf8'), [
             'TAP version 13',
-            'array',
-            { id: 1, ok: true, name: 'should be equivalent' },
-            { id: 2, ok: true, name: 'should be equivalent' },
-            { id: 3, ok: true, name: 'should be equivalent' },
-            { id: 4, ok: true, name: 'should be equivalent' },
-            { id: 5, ok: true, name: 'should be equivalent' },
-            'tests 5',
-            'pass  5',
-            'ok'
-        ]);
-    });
-    
-    test.createStream().pipe(tc);
-    
+            '# array',
+            'ok 1 should be equivalent',
+            'ok 2 should be equivalent',
+            'ok 3 should be equivalent',
+            'ok 4 should be equivalent',
+            'ok 5 should be equivalent',
+            '',
+            '1..5',
+            '# tests 5',
+            '# pass  5',
+            '',
+            '# ok'
+        ].join('\n') + '\n');
+    }));
+
     test('array', function (t) {
         t.plan(5);
-        
+
         var src = '(' + function () {
             var xs = [ 1, 2, [ 3, 4 ] ];
             var ys = [ 5, 6 ];
             g([ xs, ys ]);
         } + ')()';
-        
+
         var output = falafel(src, function (node) {
             if (node.type === 'ArrayExpression') {
                 node.update('fn(' + node.source() + ')');
             }
         });
-        
+
         var arrays = [
             [ 3, 4 ],
             [ 1, 2, [ 3, 4 ] ],
             [ 5, 6 ],
             [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
         ];
-        
+
         Function(['fn','g'], output)(
             function (xs) {
                 t.same(arrays.shift(), xs);

--- a/test/default-messages.js
+++ b/test/default-messages.js
@@ -7,7 +7,7 @@ tap.test('default messages', function (t) {
     t.plan(1);
 
     var ps = spawn(process.execPath, [path.join(__dirname, 'messages', 'defaults.js')]);
-
+    
     ps.stdout.pipe(concat(function (rows) {
 
         t.same(rows.toString('utf8'), [

--- a/test/default-messages.js
+++ b/test/default-messages.js
@@ -1,37 +1,31 @@
 var tap = require('tap');
+var path = require('path');
 var spawn = require('child_process').spawn;
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('default messages', function (t) {
     t.plan(1);
 
-    var tc = tap.createConsumer();
+    var ps = spawn(process.execPath, [path.join(__dirname, 'messages', 'defaults.js')]);
 
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        t.same(rs, [
+    ps.stdout.pipe(concat(function (rows) {
+
+        t.same(rows.toString('utf8'), [
             'TAP version 13',
-            'default messages',
-            { id: 1, ok: true, name: 'should be truthy' },
-            { id: 2, ok: true, name: 'should be falsy' },
-            { id: 3, ok: true, name: 'should be equal' },
-            { id: 4, ok: true, name: 'should not be equal' },
-            { id: 5, ok: true, name: 'should be equivalent' },
-            { id: 6, ok: true, name: 'should be equivalent' },
-            { id: 7, ok: true, name: 'should be equivalent' },
-            'tests 7',
-            'pass  7',
-            'ok'
-        ]);
-    });
-
-    var ps = spawn(process.execPath, [ __dirname + '/messages/defaults.js' ]);
-    ps.stdout.pipe(tc);
+            '# default messages',
+            'ok 1 should be truthy',
+            'ok 2 should be falsy',
+            'ok 3 should be equal',
+            'ok 4 should not be equal',
+            'ok 5 should be equivalent',
+            'ok 6 should be equivalent',
+            'ok 7 should be equivalent',
+            '',
+            '1..7',
+            '# tests 7',
+            '# pass  7',
+            '',
+            '# ok'
+        ].join('\n') + '\n\n');
+    }));
 });

--- a/test/double_end.js
+++ b/test/double_end.js
@@ -1,10 +1,11 @@
 var test = require('tap').test;
+var path = require('path');
 var concat = require('concat-stream');
 var spawn = require('child_process').spawn;
 
 test(function (t) {
     t.plan(2);
-    var ps = spawn(process.execPath, [ __dirname + '/double_end/double.js' ]);
+    var ps = spawn(process.execPath, [path.join(__dirname, 'double_end', 'double.js')]);
     ps.on('exit', function (code) {
         t.equal(code, 1);
     });

--- a/test/end-as-callback.js
+++ b/test/end-as-callback.js
@@ -4,7 +4,7 @@ var concat = require('concat-stream');
 
 tap.test("tape assert.end as callback", function (tt) {
     var test = tape.createHarness({ exit: false })
-
+    
     test.createStream().pipe(concat(function (rows) {
         tt.equal(rows.toString('utf8'), [
         'TAP version 13',

--- a/test/exit.js
+++ b/test/exit.js
@@ -1,38 +1,34 @@
 var tap = require('tap');
+var path = require('path');
 var spawn = require('child_process').spawn;
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('exit ok', function (t) {
     t.plan(2);
-    
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        t.same(rs, [
+
+    var tc = function (rows) {
+        t.same(rows.toString('utf8'), [
             'TAP version 13',
-            'array',
-            'hi',
-            { id: 1, ok: true, name: 'should be equivalent' },
-            { id: 2, ok: true, name: 'should be equivalent' },
-            { id: 3, ok: true, name: 'should be equivalent' },
-            { id: 4, ok: true, name: 'should be equivalent' },
-            { id: 5, ok: true, name: 'should be equivalent' },
-            'tests 5',
-            'pass  5',
-            'ok'
-        ]);
-    });
-    
-    var ps = spawn(process.execPath, [ __dirname + '/exit/ok.js' ]);
-    ps.stdout.pipe(tc);
+            '# array',
+            '# hi',
+            'ok 1 should be equivalent',
+            'ok 2 should be equivalent',
+            'ok 3 should be equivalent',
+            'ok 4 should be equivalent',
+            'ok 5 should be equivalent',
+            '',
+            '1..5',
+            '# tests 5',
+            '# pass  5',
+            '',
+            '# ok',
+            '', // yes, these double-blank-lines at the end are required.
+            ''  // if you can figure out how to remove them, please do!
+        ].join('\n'));
+    }
+
+    var ps = spawn(process.execPath, [path.join(__dirname, 'exit', 'ok.js')]);
+    ps.stdout.pipe(concat(tc));
     ps.on('exit', function (code) {
         t.equal(code, 0);
     });
@@ -40,34 +36,31 @@ tap.test('exit ok', function (t) {
 
 tap.test('exit fail', function (t) {
     t.plan(2);
-    
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        t.same(rs, [
+
+    var tc = function (rows) {
+        t.same(rows.toString('utf8'), [
             'TAP version 13',
-            'array',
-            { id: 1, ok: true, name: 'should be equivalent' },
-            { id: 2, ok: true, name: 'should be equivalent' },
-            { id: 3, ok: true, name: 'should be equivalent' },
-            { id: 4, ok: true, name: 'should be equivalent' },
-            { id: 5, ok: false, name: 'should be equivalent' },
-            'tests 5',
-            'pass  4',
-            'fail  1'
-        ]);
-    });
-    
-    var ps = spawn(process.execPath, [ __dirname + '/exit/fail.js' ]);
-    ps.stdout.pipe(tc);
+            '# array',
+            'ok 1 should be equivalent',
+            'ok 2 should be equivalent',
+            'ok 3 should be equivalent',
+            'ok 4 should be equivalent',
+            'not ok 5 should be equivalent',
+            '  ---',
+            '    operator: deepEqual',
+            '    expected: [ [ 1, 2, [ 3, 4444 ] ], [ 5, 6 ] ]',
+            '    actual:   [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ]',
+            '  ...',
+            '',
+            '1..5',
+            '# tests 5',
+            '# pass  4',
+            '# fail  1'
+        ].join('\n') + '\n\n');
+    };
+
+    var ps = spawn(process.execPath, [path.join(__dirname, 'exit', 'fail.js')]);
+    ps.stdout.pipe(concat(tc));
     ps.on('exit', function (code) {
         t.notEqual(code, 0);
     });
@@ -75,35 +68,32 @@ tap.test('exit fail', function (t) {
 
 tap.test('too few exit', function (t) {
     t.plan(2);
-    
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        t.same(rs, [
+
+    var tc = function (rows) {
+        t.same(rows.toString('utf8'), [
             'TAP version 13',
-            'array',
-            { id: 1, ok: true, name: 'should be equivalent' },
-            { id: 2, ok: true, name: 'should be equivalent' },
-            { id: 3, ok: true, name: 'should be equivalent' },
-            { id: 4, ok: true, name: 'should be equivalent' },
-            { id: 5, ok: true, name: 'should be equivalent' },
-            { id: 6, ok: false, name: 'plan != count' },
-            'tests 6',
-            'pass  5',
-            'fail  1'
-        ]);
-    });
-    
-    var ps = spawn(process.execPath, [ __dirname + '/exit/too_few.js' ]);
-    ps.stdout.pipe(tc);
+            '# array',
+            'ok 1 should be equivalent',
+            'ok 2 should be equivalent',
+            'ok 3 should be equivalent',
+            'ok 4 should be equivalent',
+            'ok 5 should be equivalent',
+            'not ok 6 plan != count',
+            '  ---',
+            '    operator: fail',
+            '    expected: 6',
+            '    actual:   5',
+            '  ...',
+            '',
+            '1..6',
+            '# tests 6',
+            '# pass  5',
+            '# fail  1'
+        ].join('\n') + '\n\n');
+    };
+
+    var ps = spawn(process.execPath, [path.join(__dirname, '/exit/too_few.js')]);
+    ps.stdout.pipe(concat(tc));
     ps.on('exit', function (code) {
         t.notEqual(code, 0);
     });
@@ -111,33 +101,30 @@ tap.test('too few exit', function (t) {
 
 tap.test('more planned in a second test', function (t) {
     t.plan(2);
-    
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        t.same(rs, [
+
+    var tc = function (rows) {
+        t.same(rows.toString('utf8'), [
             'TAP version 13',
-            'first',
-            { id: 1, ok: true, name: 'should be truthy' },
-            'second',
-            { id: 2, ok: true, name: 'should be truthy' },
-            { id: 3, ok: false, name: 'plan != count' },
-            'tests 3',
-            'pass  2',
-            'fail  1'
-        ]);
-    });
-    
-    var ps = spawn(process.execPath, [ __dirname + '/exit/second.js' ]);
-    ps.stdout.pipe(tc);
+            '# first',
+            'ok 1 should be truthy',
+            '# second',
+            'ok 2 should be truthy',
+            'not ok 3 plan != count',
+            '  ---',
+            '    operator: fail',
+            '    expected: 2',
+            '    actual:   1',
+            '  ...',
+            '',
+            '1..3',
+            '# tests 3',
+            '# pass  2',
+            '# fail  1'
+        ].join('\n') + '\n\n');
+    };
+
+    var ps = spawn(process.execPath, [path.join(__dirname, '/exit/second.js')]);
+    ps.stdout.pipe(concat(tc));
     ps.on('exit', function (code) {
         t.notEqual(code, 0);
     });

--- a/test/fail.js
+++ b/test/fail.js
@@ -5,7 +5,7 @@ var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
     tt.plan(1);
-
+    
     var test = tape.createHarness({ exit : false });
     var tc = function (rows) {
         tt.same(rows.toString('utf8'), [
@@ -29,31 +29,31 @@ tap.test('array test', function (tt) {
             ''
         ].join('\n'));
     };
-
+    
     test.createStream().pipe(concat(tc));
-
+    
     test('array', function (t) {
         t.plan(5);
-
+        
         var src = '(' + function () {
             var xs = [ 1, 2, [ 3, 4 ] ];
             var ys = [ 5, 6 ];
             g([ xs, ys ]);
         } + ')()';
-
+        
         var output = falafel(src, function (node) {
             if (node.type === 'ArrayExpression') {
                 node.update('fn(' + node.source() + ')');
             }
         });
-
+        
         var arrays = [
             [ 3, 4 ],
             [ 1, 2, [ 3, 4 ] ],
             [ 5, 6 ],
             [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
         ];
-
+        
         Function(['fn','g'], output)(
             function (xs) {
                 t.same(arrays.shift(), xs);

--- a/test/fail.js
+++ b/test/fail.js
@@ -1,61 +1,59 @@
 var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
     tt.plan(1);
-    
+
     var test = tape.createHarness({ exit : false });
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        tt.same(rs, [
+    var tc = function (rows) {
+        tt.same(rows.toString('utf8'), [
             'TAP version 13',
-            'array',
-            { id: 1, ok: true, name: 'should be equivalent' },
-            { id: 2, ok: true, name: 'should be equivalent' },
-            { id: 3, ok: true, name: 'should be equivalent' },
-            { id: 4, ok: true, name: 'should be equivalent' },
-            { id: 5, ok: false, name: 'should be equivalent' },
-            'tests 5',
-            'pass  4',
-            'fail  1'
-        ]);
-    });
-    
-    test.createStream().pipe(tc);
-    
+            '# array',
+            'ok 1 should be equivalent',
+            'ok 2 should be equivalent',
+            'ok 3 should be equivalent',
+            'ok 4 should be equivalent',
+            'not ok 5 should be equivalent',
+            '  ---',
+            '    operator: deepEqual',
+            '    expected: [ [ 1, 2, [ 3, 4444 ] ], [ 5, 6 ] ]',
+            '    actual:   [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ]',
+            '  ...',
+            '',
+            '1..5',
+            '# tests 5',
+            '# pass  4',
+            '# fail  1',
+            ''
+        ].join('\n'));
+    };
+
+    test.createStream().pipe(concat(tc));
+
     test('array', function (t) {
         t.plan(5);
-        
+
         var src = '(' + function () {
             var xs = [ 1, 2, [ 3, 4 ] ];
             var ys = [ 5, 6 ];
             g([ xs, ys ]);
         } + ')()';
-        
+
         var output = falafel(src, function (node) {
             if (node.type === 'ArrayExpression') {
                 node.update('fn(' + node.source() + ')');
             }
         });
-        
+
         var arrays = [
             [ 3, 4 ],
             [ 1, 2, [ 3, 4 ] ],
             [ 5, 6 ],
             [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
         ];
-        
+
         Function(['fn','g'], output)(
             function (xs) {
                 t.same(arrays.shift(), xs);

--- a/test/max_listeners.js
+++ b/test/max_listeners.js
@@ -1,5 +1,8 @@
 var spawn = require('child_process').spawn;
-var ps = spawn(process.execPath, [ __dirname + '/max_listeners/source.js' ]);
+var path = require('path');
+
+var ps = spawn(process.execPath, [path.join(__dirname, 'max_listeners', 'source.js')]);
+
 ps.stdout.pipe(process.stdout, { end : false });
 
 ps.stderr.on('data', function (buf) {

--- a/test/nested-sync-noplan-noend.js
+++ b/test/nested-sync-noplan-noend.js
@@ -27,15 +27,15 @@ tap.test('nested sync test without plan or end', function (tt) {
 
     test('nested without plan or end', function(t) {
         t.test('first', function(q) {
-            setTimeout(function first() {
+            setTimeout(function first() { 
                 q.ok(true);
-                q.end()
+                q.end() 
             }, 10);
         });
         t.test('second', function(q) {
-            setTimeout(function second() {
+            setTimeout(function second() { 
                 q.ok(true);
-                q.end()
+                q.end() 
             }, 10);
         });
     });

--- a/test/nested-sync-noplan-noend.js
+++ b/test/nested-sync-noplan-noend.js
@@ -1,49 +1,41 @@
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('nested sync test without plan or end', function (tt) {
     tt.plan(1);
 
     var test = tape.createHarness();
-    var tc = tap.createConsumer();
-
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        var expected = [
+    var tc = function (rows) {
+       tt.same(rows.toString('utf8'), [
             'TAP version 13',
-            'nested without plan or end',
-            'first',
-            { id: 1, ok: true, name: 'should be truthy' },
-            'second',
-            { id: 2, ok: true, name: 'should be truthy' },
-            'tests 2',
-            'pass  2',
-            'ok'
-        ]
-        tt.same(rs, expected);
-    });
+            '# nested without plan or end',
+            '# first',
+            'ok 1 should be truthy',
+            '# second',
+            'ok 2 should be truthy',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  2',
+            '',
+            '# ok'
+        ].join('\n') + '\n');
+    };
 
-    test.createStream().pipe(tc);
+    test.createStream().pipe(concat(tc));
 
     test('nested without plan or end', function(t) {
         t.test('first', function(q) {
-            setTimeout(function first() { 
+            setTimeout(function first() {
                 q.ok(true);
-                q.end() 
+                q.end()
             }, 10);
         });
         t.test('second', function(q) {
-            setTimeout(function second() { 
+            setTimeout(function second() {
                 q.ok(true);
-                q.end() 
+                q.end()
             }, 10);
         });
     });

--- a/test/nested.js
+++ b/test/nested.js
@@ -5,7 +5,7 @@ var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
     tt.plan(1);
-
+    
     var test = tape.createHarness();
     var tc = function (rows) {
         tt.same(rows.toString('utf8'), [
@@ -29,40 +29,40 @@ tap.test('array test', function (tt) {
             '# ok'
         ].join('\n') + '\n');
     };
-
+    
     test.createStream().pipe(concat(tc));
-
+    
     test('nested array test', function (t) {
         t.plan(6);
-
+        
         var src = '(' + function () {
             var xs = [ 1, 2, [ 3, 4 ] ];
             var ys = [ 5, 6 ];
             g([ xs, ys ]);
         } + ')()';
-
+        
         var output = falafel(src, function (node) {
             if (node.type === 'ArrayExpression') {
                 node.update('fn(' + node.source() + ')');
             }
         });
-
+        
         t.test('inside test', function (q) {
             q.plan(2);
             q.ok(true);
-
+            
             setTimeout(function () {
                 q.ok(true);
             }, 100);
         });
-
+        
         var arrays = [
             [ 3, 4 ],
             [ 1, 2, [ 3, 4 ] ],
             [ 5, 6 ],
             [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
         ];
-
+        
         Function(['fn','g'], output)(
             function (xs) {
                 t.same(arrays.shift(), xs);

--- a/test/nested.js
+++ b/test/nested.js
@@ -1,75 +1,68 @@
 var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
     tt.plan(1);
-    
+
     var test = tape.createHarness();
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        tt.same(rs, [
+    var tc = function (rows) {
+        tt.same(rows.toString('utf8'), [
             'TAP version 13',
-            'nested array test',
-            { id: 1, ok: true, name: 'should be equivalent' },
-            { id: 2, ok: true, name: 'should be equivalent' },
-            { id: 3, ok: true, name: 'should be equivalent' },
-            { id: 4, ok: true, name: 'should be equivalent' },
-            { id: 5, ok: true, name: 'should be equivalent' },
-            'inside test',
-            { id: 6, ok: true, name: 'should be truthy' },
-            { id: 7, ok: true, name: 'should be truthy' },
-            'another',
-            { id: 8, ok: true, name: 'should be truthy' },
-            'tests 8',
-            'pass  8',
-            'ok'
-        ]);
-    });
-    
-    test.createStream().pipe(tc);
-    
+            '# nested array test',
+            'ok 1 should be equivalent',
+            'ok 2 should be equivalent',
+            'ok 3 should be equivalent',
+            'ok 4 should be equivalent',
+            'ok 5 should be equivalent',
+            '# inside test',
+            'ok 6 should be truthy',
+            'ok 7 should be truthy',
+            '# another',
+            'ok 8 should be truthy',
+            '',
+            '1..8',
+            '# tests 8',
+            '# pass  8',
+            '',
+            '# ok'
+        ].join('\n') + '\n');
+    };
+
+    test.createStream().pipe(concat(tc));
+
     test('nested array test', function (t) {
         t.plan(6);
-        
+
         var src = '(' + function () {
             var xs = [ 1, 2, [ 3, 4 ] ];
             var ys = [ 5, 6 ];
             g([ xs, ys ]);
         } + ')()';
-        
+
         var output = falafel(src, function (node) {
             if (node.type === 'ArrayExpression') {
                 node.update('fn(' + node.source() + ')');
             }
         });
-        
+
         t.test('inside test', function (q) {
             q.plan(2);
             q.ok(true);
-            
+
             setTimeout(function () {
                 q.ok(true);
             }, 100);
         });
-        
+
         var arrays = [
             [ 3, 4 ],
             [ 1, 2, [ 3, 4 ] ],
             [ 5, 6 ],
             [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
         ];
-        
+
         Function(['fn','g'], output)(
             function (xs) {
                 t.same(arrays.shift(), xs);

--- a/test/only.js
+++ b/test/only.js
@@ -1,38 +1,29 @@
 var tap = require('tap');
 var tape = require('../');
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('tape only test', function (tt) {
     var test = tape.createHarness({ exit: false });
-    var tc = tap.createConsumer();
     var ran = [];
 
-    var rows = []
-    tc.on('data', function (r) { rows.push(r) })
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id: r.id, ok: r.ok, name: trim(r.name) };
-            }
-            else {
-                return r;
-            }
-        })
-
-        tt.deepEqual(rs, [
+    var tc = function (rows) {
+        tt.deepEqual(rows.toString('utf8'), [
             'TAP version 13',
-            'run success',
-            { id: 1, ok: true, name: 'assert name'},
-            'tests 1',
-            'pass  1',
-            'ok'
-        ])
+            '# run success',
+            'ok 1 assert name',
+            '',
+            '1..1',
+            '# tests 1',
+            '# pass  1',
+            '',
+            '# ok'
+        ].join('\n') + '\n');
         tt.deepEqual(ran, [ 3 ]);
 
         tt.end()
-    })
+    };
 
-    test.createStream().pipe(tc)
+    test.createStream().pipe(concat(tc));
 
     test("never run fail", function (t) {
         ran.push(1);

--- a/test/require.js
+++ b/test/require.js
@@ -4,7 +4,7 @@ var concat = require('concat-stream');
 
 tap.test('requiring a single module', function (t) {
     t.plan(2);
-
+    
     var tc = function (rows) {
         t.same(rows.toString('utf8'), [
             'TAP version 13',
@@ -21,7 +21,7 @@ tap.test('requiring a single module', function (t) {
             '# ok'
         ].join('\n') + '\n\n');
     };
-
+    
     var ps = tape('-r ./require/a require/test-a.js');
     ps.stdout.pipe(concat(tc));
     ps.on('exit', function (code) {
@@ -31,7 +31,7 @@ tap.test('requiring a single module', function (t) {
 
 tap.test('requiring multiple modules', function (t) {
     t.plan(2);
-
+    
     var tc = function (rows) {
         t.same(rows.toString('utf8'), [
             'TAP version 13',
@@ -53,7 +53,7 @@ tap.test('requiring multiple modules', function (t) {
             '# ok'
         ].join('\n') + '\n\n');
     };
-
+    
     var ps = tape('-r ./require/a -r ./require/b require/test-a.js require/test-b.js');
     ps.stdout.pipe(concat(tc));
     ps.on('exit', function (code) {

--- a/test/require.js
+++ b/test/require.js
@@ -1,36 +1,29 @@
 var tap = require('tap');
 var spawn = require('child_process').spawn;
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('requiring a single module', function (t) {
     t.plan(2);
-    
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        t.same(rs, [
+
+    var tc = function (rows) {
+        t.same(rows.toString('utf8'), [
             'TAP version 13',
-            'module-a',
-            { id: 1, ok: true, name: 'loaded module a' },
-            'test-a',
-            { id: 2, ok: true, name: 'module-a loaded in same context'},
-            { id: 3, ok: true, name: 'test ran after module-a was loaded'},
-            'tests 3',
-            'pass  3',
-            'ok'
-        ]);
-    });
-    
+            '# module-a',
+            'ok 1 loaded module a',
+            '# test-a',
+            'ok 2 module-a loaded in same context',
+            'ok 3 test ran after module-a was loaded',
+            '',
+            '1..3',
+            '# tests 3',
+            '# pass  3',
+            '',
+            '# ok'
+        ].join('\n') + '\n\n');
+    };
+
     var ps = tape('-r ./require/a require/test-a.js');
-    ps.stdout.pipe(tc);
+    ps.stdout.pipe(concat(tc));
     ps.on('exit', function (code) {
         t.equal(code, 0);
     });
@@ -38,38 +31,31 @@ tap.test('requiring a single module', function (t) {
 
 tap.test('requiring multiple modules', function (t) {
     t.plan(2);
-    
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        t.same(rs, [
+
+    var tc = function (rows) {
+        t.same(rows.toString('utf8'), [
             'TAP version 13',
-            'module-a',
-            { id: 1, ok: true, name: 'loaded module a' },
-            'module-b',
-            { id: 2, ok: true, name: 'loaded module b' },
-            'test-a',
-            { id: 3, ok: true, name: 'module-a loaded in same context'},
-            { id: 4, ok: true, name: 'test ran after module-a was loaded'},
-            'test-b',
-            { id: 5, ok: true, name: 'module-b loaded in same context'},
-            { id: 6, ok: true, name: 'test ran after module-b was loaded'},
-            'tests 6',
-            'pass  6',
-            'ok'
-        ]);
-    });
-    
+            '# module-a',
+            'ok 1 loaded module a',
+            '# module-b',
+            'ok 2 loaded module b',
+            '# test-a',
+            'ok 3 module-a loaded in same context',
+            'ok 4 test ran after module-a was loaded',
+            '# test-b',
+            'ok 5 module-b loaded in same context',
+            'ok 6 test ran after module-b was loaded',
+            '',
+            '1..6',
+            '# tests 6',
+            '# pass  6',
+            '',
+            '# ok'
+        ].join('\n') + '\n\n');
+    };
+
     var ps = tape('-r ./require/a -r ./require/b require/test-a.js require/test-b.js');
-    ps.stdout.pipe(tc);
+    ps.stdout.pipe(concat(tc));
     ps.on('exit', function (code) {
         t.equal(code, 0);
     });

--- a/test/skip.js
+++ b/test/skip.js
@@ -28,13 +28,6 @@ tap.test('test SKIP comment', function (assert) {
     });
 });
 
-
-test('do not skip this', { skip: false }, function(t) {
-    t.pass('this should run');
-    ran ++;
-    t.end();
-});
-
 test('skip this', { skip: true }, function(t) {
     t.fail('this should not even run');
 	ran++;
@@ -43,26 +36,16 @@ test('skip this', { skip: true }, function(t) {
 
 test.skip('skip this too', function(t) {
     t.fail('this should not even run');
-	ran++;
+    ran++;
     t.end();
 });
 
 test('skip subtest', function(t) {
-    ran ++;
-    t.test('do not skip this', { skip: false }, function(t) {
-        ran ++;
-        t.pass('this should run');
-        t.end();
-    });
+    ran++;
     t.test('skip this', { skip: true }, function(t) {
         t.fail('this should not even run');
         t.end();
     });
-    t.end();
-});
-
-test('right number of tests ran', function(t) {
-    t.equal(ran, 3, 'ran the right number of tests');
     t.end();
 });
 

--- a/test/throws.js
+++ b/test/throws.js
@@ -14,24 +14,6 @@ function getNonFunctionMessage(fn) {
     }
 }
 
-tape('throws', function (t) {
-    t.throws(fn);
-    t.end();
-});
-
-tape('throws (RegExp match)', function (t) {
-    t.throws(fn, /RegExp/, 'regex with no anchors');
-    t.throws(fn, /^TypeError: Reg/, 'regex with starting anchor');
-    t.throws(fn, /RegExp$/, 'regex with ending anchor');
-    t.throws(fn, /^TypeError: RegExp$/, 'regex with both anchors');
-    t.end();
-});
-
-tape('throws (Function match)', function (t) {
-    t.throws(fn, TypeError);
-    t.end();
-});
-
 tap.test('failures', function (tt) {
     tt.plan(1);
 

--- a/test/timeoutAfter.js
+++ b/test/timeoutAfter.js
@@ -4,7 +4,7 @@ var concat = require('concat-stream');
 
 tap.test('timeoutAfter test', function (tt) {
     tt.plan(1);
-
+    
     var test = tape.createHarness();
     var tc = function (rows) {
         tt.same(rows.toString('utf8'), [
@@ -21,9 +21,9 @@ tap.test('timeoutAfter test', function (tt) {
             '# fail  1'
         ].join('\n') + '\n');
     };
-
+    
     test.createStream().pipe(concat(tc));
-
+    
     test('timeoutAfter', function (t) {
         t.plan(1);
         t.timeoutAfter(1);

--- a/test/timeoutAfter.js
+++ b/test/timeoutAfter.js
@@ -1,34 +1,29 @@
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('timeoutAfter test', function (tt) {
     tt.plan(1);
-    
+
     var test = tape.createHarness();
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        tt.same(rs, [
+    var tc = function (rows) {
+        tt.same(rows.toString('utf8'), [
             'TAP version 13',
-            'timeoutAfter',
-            { id: 1, ok: false, name: 'test timed out after 1ms' },
-            'tests 1',
-            'pass  0',
-            'fail  1'
-        ]);
-    });
-    
-    test.createStream().pipe(tc);
-    
+            '# timeoutAfter',
+            'not ok 1 test timed out after 1ms',
+            '  ---',
+            '    operator: fail',
+            '  ...',
+            '',
+            '1..1',
+            '# tests 1',
+            '# pass  0',
+            '# fail  1'
+        ].join('\n') + '\n');
+    };
+
+    test.createStream().pipe(concat(tc));
+
     test('timeoutAfter', function (t) {
         t.plan(1);
         t.timeoutAfter(1);

--- a/test/too_many.js
+++ b/test/too_many.js
@@ -5,7 +5,7 @@ var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
     tt.plan(1);
-
+    
     var test = tape.createHarness({ exit : false });
     var tc = function (rows) {
         tt.same(rows.toString('utf8'), [
@@ -29,31 +29,31 @@ tap.test('array test', function (tt) {
             '# fail  1'
         ].join('\n') + '\n');
     };
-
+    
     test.createStream().pipe(concat(tc));
-
+    
     test('array', function (t) {
         t.plan(3);
-
+        
         var src = '(' + function () {
             var xs = [ 1, 2, [ 3, 4 ] ];
             var ys = [ 5, 6 ];
             g([ xs, ys ]);
         } + ')()';
-
+        
         var output = falafel(src, function (node) {
             if (node.type === 'ArrayExpression') {
                 node.update('fn(' + node.source() + ')');
             }
         });
-
+        
         var arrays = [
             [ 3, 4 ],
             [ 1, 2, [ 3, 4 ] ],
             [ 5, 6 ],
             [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
         ];
-
+        
         Function(['fn','g'], output)(
             function (xs) {
                 t.same(arrays.shift(), xs);

--- a/test/too_many.js
+++ b/test/too_many.js
@@ -1,62 +1,59 @@
 var falafel = require('falafel');
 var tape = require('../');
 var tap = require('tap');
-var trim = require('string.prototype.trim');
+var concat = require('concat-stream');
 
 tap.test('array test', function (tt) {
     tt.plan(1);
-    
+
     var test = tape.createHarness({ exit : false });
-    var tc = tap.createConsumer();
-    
-    var rows = [];
-    tc.on('data', function (r) { rows.push(r) });
-    tc.on('end', function () {
-        var rs = rows.map(function (r) {
-            if (r && typeof r === 'object') {
-                return { id : r.id, ok : r.ok, name : trim(r.name) };
-            }
-            else return r;
-        });
-        tt.same(rs, [
+    var tc = function (rows) {
+        tt.same(rows.toString('utf8'), [
             'TAP version 13',
-            'array',
-            { id: 1, ok: true, name: 'should be equivalent' },
-            { id: 2, ok: true, name: 'should be equivalent' },
-            { id: 3, ok: true, name: 'should be equivalent' },
-            { id: 4, ok: true, name: 'should be equivalent' },
-            { id: 5, ok: false, name: 'plan != count' },
-            { id: 6, ok: true, name: 'should be equivalent' },
-            'tests 6',
-            'pass  5',
-            'fail  1'
-        ]);
-    });
-    
-    test.createStream().pipe(tc);
-    
+            '# array',
+            'ok 1 should be equivalent',
+            'ok 2 should be equivalent',
+            'ok 3 should be equivalent',
+            'ok 4 should be equivalent',
+            'not ok 5 plan != count',
+            '  ---',
+            '    operator: fail',
+            '    expected: 3',
+            '    actual:   4',
+            '  ...',
+            'ok 6 should be equivalent',
+            '',
+            '1..6',
+            '# tests 6',
+            '# pass  5',
+            '# fail  1'
+        ].join('\n') + '\n');
+    };
+
+    test.createStream().pipe(concat(tc));
+
     test('array', function (t) {
         t.plan(3);
-        
+
         var src = '(' + function () {
             var xs = [ 1, 2, [ 3, 4 ] ];
             var ys = [ 5, 6 ];
             g([ xs, ys ]);
         } + ')()';
-        
+
         var output = falafel(src, function (node) {
             if (node.type === 'ArrayExpression') {
                 node.update('fn(' + node.source() + ')');
             }
         });
-        
+
         var arrays = [
             [ 3, 4 ],
             [ 1, 2, [ 3, 4 ] ],
             [ 5, 6 ],
             [ [ 1, 2, [ 3, 4 ] ], [ 5, 6 ] ],
         ];
-        
+
         Function(['fn','g'], output)(
             function (xs) {
                 t.same(arrays.shift(), xs);


### PR DESCRIPTION
This pull request updates `devDependencies` to the _latest_ version of `tap` & `tap-parser`
( as discussed in: https://github.com/substack/tape/issues/312 )

removed `tap.createConsumer` in favour of `concat-stream` which is being used in: [`test/circular-things.js#L3`](https://github.com/substack/tape/blob/092344b906cd3774ba1812d2db431e77916c9f19/test/circular-things.js#L3)

The full discussion of the changes made in this PR can be seen in: https://github.com/substack/tape/pull/314
However a _new_ PR was created to keep the commit history clean 
( _one commit per change/file_ requested by @ljharb in: https://github.com/substack/tape/pull/314#issuecomment-244449188 )