### PR TITLE
Add an alternative ES6 tape runner

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -128,7 +128,7 @@ By default, uncaught exceptions in your tests will not be intercepted, and will 
 
 - CoffeeScript support with https://www.npmjs.com/package/coffeetape
 - Promise support with https://www.npmjs.com/package/blue-tape
-- ES6 support with https://www.npmjs.com/package/babel-tape-runner
+- ES6 support with https://www.npmjs.com/package/babel-tape-runner or https://www.npmjs.com/package/buble-tape-runner
 
 # methods
 


### PR DESCRIPTION
I wrapped Buble and Reify for running ES6 syntax tests for my own purposes. Maybe someone else would enjoy it, too.
