### PR TITLE
Show failure location even if windows driver letter is lowercase

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -263,9 +263,9 @@ Test.prototype._assert = function assert (ok, opts) {
                 Last part captures file path plus line no (and optional
                 column no).
 
-                    /((?:\/|[A-Z]:\\)[^:\)]+:(\d+)(?::(\d+))?)/
+                    /((?:\/|[a-zA-Z]:\\)[^:\)]+:(\d+)(?::(\d+))?)/
             */
-            var re = /^(?:[^\s]*\s*\bat\s+)(?:(.*)\s+\()?((?:\/|[A-Z]:\\)[^:\)]+:(\d+)(?::(\d+))?)/
+            var re = /^(?:[^\s]*\s*\bat\s+)(?:(.*)\s+\()?((?:\/|[a-zA-Z]:\\)[^:\)]+:(\d+)(?::(\d+))?)/
             var m = re.exec(err[i]);
 
             if (!m) {


### PR DESCRIPTION
I had a fix for this issue not so long ago (#316), but as it turns out, on our work machines the driver letter is lowercase, so I wasn't able to impress my colleagues with this new (to them) feature of tape.
Probably should have tried it there instead of just on my home PC, but better later than never.
