### PR TITLE
tap-min moved to derhuerst/tap-min

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -101,7 +101,7 @@ that will output something pretty if you pipe TAP into them:
  - https://github.com/juliangruber/tap-bail
  - https://github.com/kirbysayshi/tap-browser-color
  - https://github.com/gummesson/tap-json
- - https://github.com/gummesson/tap-min
+ - https://github.com/derhuerst/tap-min
  - https://github.com/calvinmetcalf/tap-nyan
  - https://www.npmjs.org/package/tap-pessimist
  - https://github.com/toolness/tap-prettify


### PR DESCRIPTION
Thanks for tape, it's a great tool!

I took over the maintenance of tap-min. `tap-min@1.2.0` has been published from [derhuerst/tap-min](https://github.com/derhuerst/tap-min). This PR updates the link in the readme.