### PR TITLE
t.throws() broken when awaiting on an async function that throws an error

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -431,66 +431,97 @@ Test.prototype.notDeepLooseEqual
 };
 
 Test.prototype['throws'] = function (fn, expected, msg, extra) {
-    if (typeof expected === 'string') {
-        msg = expected;
-        expected = undefined;
-    }
-
+    var self = this;
     var caught = undefined;
 
     try {
-        fn();
+      var result = fn();
+      if (result && result instanceof Promise) {
+        result.then(function(){
+          handleCatch(undefined);
+        }).catch(function(err){
+          handleCatch(err);
+        })
+        return;
+      }
     } catch (err) {
-        caught = { error : err };
-        if ((err != null) && (!isEnumerable(err, 'message') || !has(err, 'message'))) {
-            var message = err.message;
-            delete err.message;
-            err.message = message;
-        }
+        return handleCatch(err);
     }
 
-    var passed = caught;
+    function handleCatch (err) {
+      var errorsMatched = false
+      var noErrors = err === undefined
 
-    if (expected instanceof RegExp) {
-        passed = expected.test(caught && caught.error);
-        expected = String(expected);
+      if (typeof fn !== 'function') {
+        var err = new TypeError('fn is not a function')
+        noErrors = true
+      }
+
+      if ((err != null) && (!isEnumerable(err, 'message') || !has(err, 'message'))) {
+          var message = err.message;
+          delete err.message;
+          err.message = message;
+      }
+
+      if (typeof expected === 'string') { //this is a dangerous signature
+          msg = expected; // easy to pass a string when you meant a regex
+          expected = undefined; // then not notice any throw passes
+          errorsMatched = true;
+      }
+      else if (expected instanceof RegExp) {
+          errorsMatched = expected.test(err);
+      }
+      else if (typeof expected === 'function' && err) {
+          err = err.constructor;
+      }
+
+      self._assert(!noErrors && errorsMatched, { // prints when errorsMatched = false
+          message : msg || 'should throw',
+          operator : 'throws',
+          actual : err,
+          expected : expected,
+          error: err,
+          extra : extra
+      });
     }
-
-    if (typeof expected === 'function' && caught) {
-        passed = caught.error instanceof expected;
-        caught.error = caught.error.constructor;
-    }
-
-    this._assert(typeof fn === 'function' && passed, {
-        message : defined(msg, 'should throw'),
-        operator : 'throws',
-        actual : caught && caught.error,
-        expected : expected,
-        error: !passed && caught && caught.error,
-        extra : extra
-    });
+    handleCatch(undefined);
 };
 
 Test.prototype.doesNotThrow = function (fn, expected, msg, extra) {
+    var self = this;
+    var err = undefined;
+
     if (typeof expected === 'string') {
         msg = expected;
         expected = undefined;
     }
-    var caught = undefined;
+
     try {
-        fn();
+      var result = fn();
+      if (result && result instanceof Promise) {
+        result.then(function(){
+          handleCatch(undefined)
+        }).catch(function(err){
+          handleCatch(err);
+        })
+        return;
+      }
+    } catch (err) {
+        return handleCatch(err);
     }
-    catch (err) {
-        caught = { error : err };
+
+    function handleCatch (err) {
+      self._assert(err === undefined, {
+          message : msg || 'should not throw',
+          operator : 'throws',
+          actual : err,
+          expected : expected,
+          error : err,
+          extra : extra
+      });
     }
-    this._assert(!caught, {
-        message : defined(msg, 'should not throw'),
-        operator : 'throws',
-        actual : caught && caught.error,
-        expected : expected,
-        error : caught && caught.error,
-        extra : extra
-    });
+
+    handleCatch(undefined) //only sync functions with no errors reach here
 };
 
 Test.skip = function (name_, _opts, _cb) {

--- a/test/throws.js
+++ b/test/throws.js
@@ -155,9 +155,13 @@ tap.test('failures', function (tt) {
            + 'ok 12 getter is still the same\n'
            + '# throws null\n'
            + 'ok 13 throws null\n'
-           + '\n1..13\n'
-           + '# tests 13\n'
-           + '# pass  4\n'
+           + '# throws string\n'
+           + 'ok 14 should throw\n'
+           + '# throws regex error_sync\n'
+           + 'ok 15 should throw\n'
+           + '\n1..15\n'
+           + '# tests 15\n'
+           + '# pass  6\n'
            + '# fail  9\n'
         );
     }));
@@ -191,4 +195,19 @@ tap.test('failures', function (tt) {
       t.throws(function () { throw null; }, 'throws null');
       t.end();
     });
+
+    test('throws string', function (t) {
+      t.plan(1);
+      t.throws(function(){
+        throw 'bad_boy_threw_string'
+      }, /bad_boy_threw_string/)
+    });
+
+    test('throws regex error_sync', function (t) {
+      t.plan(1);
+      t.throws(function(){
+        throw new Error('crufty')
+      }, /crufty/)
+    });
 });
+

--- a/test/throws_harmony.js
+++ b/test/throws_harmony.js
@@ -1,0 +1,146 @@
+var tape = require('../');
+var tap = require('tap');
+var concat = require('concat-stream');
+
+var stripFullStack = require('./common').stripFullStack;
+
+function fn() {
+    throw new TypeError('RegExp');
+}
+
+function getNonFunctionMessage(fn) {
+    try {
+        fn();
+    } catch (e) {
+        return e.message;
+    }
+}
+
+var getter = function () { return 'message'; };
+var messageGetterError = Object.defineProperty(
+    { custom: 'error' },
+    'message',
+    { configurable: true, enumerable: true, get: getter }
+);
+var thrower = function () { throw messageGetterError; };
+
+function exCustomError(message, name, code) {
+  var fn = 'CustomError' //needs to be the same as function name
+  var myerr = new Error(message)
+  myerr.message = message ? message : ''
+  myerr.name = name ? name : fn
+  if (code) {
+    myerr.code = code
+    var code_pretty = typeof code === 'number' ? 'code:'+code+' ' : code+':'
+    myerr.stack = myerr.stack.replace(myerr.name+':', myerr.name+': '+code_pretty)
+  }
+  myerr.stack = myerr.stack.replace(new RegExp("^\\s*at (new )?"+fn+".*$", 'm'), '')
+
+  myerr.inspect = function () { // makes console.log(err) pretty
+      return myerr.stack;
+  };
+
+  myerr.toString = function(){
+    return myerr.stack
+  }
+
+  return myerr
+}
+
+tap.test('harmony only tests', function (tt) {
+    var test = tape.createHarness();
+    test.createStream().pipe(concat(function (body) {
+        var out = body.toString('utf8')
+
+        var numTests = /^#\stests\s+([0-9]+)/m.exec(out)
+        numTests = numTests ? numTests[1] : 0
+        var pass = /^#\spass\s+([0-9]+)/m.exec(out)
+        pass = pass ? pass[1] : 0
+        var fail = /^#\sfail\s+([0-9]+)/m.exec(out)
+        fail = fail ? fail[1] : 0
+
+        var msgs = out.match(/^((?:(?:not ok)|(?:ok))\s+[0-9]+.*$)/mg)
+        tt.equal(fail, '2');
+        tt.equal(pass, '7');
+
+        tt.notEqual(msgs.indexOf('not ok 1 should throw'), -1);
+        tt.notEqual(msgs.indexOf('not ok 2 should throw'), -1);
+        tt.notEqual(msgs.indexOf('ok 3 should throw'), -1);
+        tt.notEqual(msgs.indexOf('ok 4 should throw'), -1);
+        tt.notEqual(msgs.indexOf('ok 5 should throw'), -1);
+        tt.notEqual(msgs.indexOf('ok 6 should throw'), -1);
+        tt.notEqual(msgs.indexOf('ok 7 should throw'), -1);
+        tt.notEqual(msgs.indexOf('ok 8 should not throw'), -1);
+        tt.notEqual(msgs.indexOf('ok 9 should not throw'), -1);
+
+        tt.end()
+    }));
+
+
+  function syncboy(){
+    throw new Error('a fit')
+  }
+
+  function asyncgirl() {
+    return new Promise(function(resolve, reject){
+      throw new Error('slugger'); //turns into promise rejection
+      resolve() //never happens, rejection gets returned
+    })
+  }
+
+  test('notice lack of sync throw',function(t) {
+    t.throws( function(){}, /a fit/)
+    t.end()
+  })
+
+  test('notice lack of async throw',function(t) {
+    t.throws( async function(){}, /a fit/)
+    t.end()
+  })
+
+  test('notice returned promise rejection', function(t){
+    t.plan(1)
+    t.throws( async function(){
+      return Promise.reject(new Error('a fit'))
+    }, /a fit/)
+  })
+
+  test('sync throw directly inside async',function(t) {
+    t.plan(1)
+    t.throws( async function(){
+        throw new Error('slugger')
+    }, /slugger/)
+  })
+
+  test('sync throw inside async function', function(t){
+    t.plan(1)
+    t.throws( async function(){
+      syncboy()
+    }, /a fit/)
+  })
+
+  test('returned reject in async func', function(t){
+    t.plan(1)
+    t.throws( async function(){
+      return Promise.reject('a fit')
+    }, /a fit/)
+  })
+
+
+  test('throw inside await async func', function(t){
+    t.plan(1)
+    t.throws( async function(){
+      await asyncgirl()
+    }, /slugger/)
+  })
+
+  test('doesNotThrow sync', function(t){
+    t.plan(1)
+    t.doesNotThrow( function(){} )
+  })
+
+  test('doesNotThrow async', function(t){
+    t.plan(1)
+    t.doesNotThrow( async function(){} )
+  })
+});


### PR DESCRIPTION
I can catch await ex1() with a try/catch statement so seems broken.
```
async function ex1() {
  throw new Error('slips by')
}

test('throw inside await async func is not noticed', function(t){
  t.plan(1)
  t.throws( async function(){
    await ex1()
  }, /slips by/)
})
```

This patch makes throws and doesNotThrows notice errors
that get turned into unhandled promise rejections where possible.
I used (more complex) promises to avoid async functions in the code.
The only async functions are in test/throws_harmony.js which you
need to run manually with node --harmony test/throws_harmony.js

There is a version of TAP that works with harmony...

What do you guys think?