### PR TITLE
Import EventEmitter as default from events

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -1,5 +1,5 @@
 var defined = require('defined');
-var EventEmitter = require('events').EventEmitter;
+var EventEmitter = require('events'); EventEmitter = EventEmitter.EventEmitter || EventEmitter;
 var inherits = require('inherits');
 var through = require('through');
 var resumer = require('resumer');

--- a/lib/test.js
+++ b/lib/test.js
@@ -2,7 +2,7 @@ var deepEqual = require('deep-equal');
 var defined = require('defined');
 var path = require('path');
 var inherits = require('inherits');
-var EventEmitter = require('events').EventEmitter;
+var EventEmitter = require('events'); EventEmitter = EventEmitter.EventEmitter || EventEmitter;
 var has = require('has');
 var trim = require('string.prototype.trim');
 var bind = require('function-bind');


### PR DESCRIPTION
This was causing some issues when building with rollup for the browser. It looks like the default export has been the `EventEmitter` class since node v4.

I can add support for legacy node versions if you wish.

🍻 