### PR TITLE
Fix spurious "test exited without ending"

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -30,6 +30,10 @@ opts._.forEach(function (arg) {
     // Note: `glob.sync` may throw an error and crash the node process.
     var files = glob.sync(arg);
 
+    if (!Array.isArray(files)) {
+      throw new TypeError('unknown error: glob.sync did not return an array or throw. Please report this.');
+    }
+
     files.forEach(function (file) {
         require(resolvePath(cwd, file));
     });

--- a/bin/tape
+++ b/bin/tape
@@ -26,10 +26,12 @@ opts.require.forEach(function(module) {
 });
 
 opts._.forEach(function (arg) {
-    glob(arg, function (err, files) {
-        files.forEach(function (file) {
-            require(resolvePath(cwd, file));
-        });
+    // If glob does not match, `files` will be an empty array.
+    // Note: `glob.sync` may throw an error and crash the node process.
+    var files = glob.sync(arg);
+
+    files.forEach(function (file) {
+        require(resolvePath(cwd, file));
     });
 });
 


### PR DESCRIPTION
Fixes: #223

This PR ensures that all test files are required on the first tick.

To make `tape` happy, all tests need to be queued on the first tick. Tape assumes that tests are done when there's nothing in the queue. 

Right now, the `tape` binary is asynchronously resolving the globs and queuing up the tests as those callbacks are called. This can lead to spurious "test exited without ending" errors.

@Raynos identified this line as the issue a while back https://github.com/substack/tape/issues/223#issuecomment-167920577 Let's finally fix this :)