### PR TITLE
Use local reference for clearTimeout global

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -16,6 +16,7 @@ var nextTick = typeof setImmediate !== 'undefined'
     : process.nextTick
 ;
 var safeSetTimeout = setTimeout;
+var safeClearTimeout = clearTimeout;
 
 inherits(Test, EventEmitter);
 
@@ -127,7 +128,7 @@ Test.prototype.timeoutAfter = function(ms) {
         self.end();
     }, ms);
     this.once('end', function() {
-        clearTimeout(timeout);
+        safeClearTimeout(timeout);
     });
 }
 


### PR DESCRIPTION
This ensures it is robust against stubbing in tests as is done with safeSetTimeout.

References #383.

This doesn't really fix the issue in #383, but at least allows the use of a timeout to work around it partially and prevent premature exiting of the process.