### PR TITLE
#395 Use default `require.extensions`

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -18,11 +18,12 @@ if (typeof opts.require === 'string') {
 }
 
 opts.require.forEach(function (module) {
+    var options  = { basedir: cwd, extensions: Object.keys(require.extensions) };
     if (module) {
         /* This check ensures we ignore `-r ""`, trailing `-r`, or
          * other silly things the user might (inadvertently) be doing.
          */
-        require(resolveModule(module, { basedir: cwd }));
+        require(resolveModule(module, options));
     }
 });
 


### PR DESCRIPTION
Fixes https://github.com/browserify/resolve/issues/137 & Fixes #395 by using default `require.extensions` collection.