### PR TITLE
normalize path separators in stripFullStack

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -39,7 +39,8 @@ module.exports.stripFullStack = function (output) {
       var stripChangingData = function (line) {
           var withoutTestDir = line.replace(__dirname, '$TEST');
           var withoutPackageDir = withoutTestDir.replace(path.dirname(__dirname), '$TAPE');
-          var withoutLineNumbers = withoutPackageDir.replace(/:\d+:\d+/g, ':$LINE:$COL');
+          var withoutPathSep = withoutPackageDir.replace(new RegExp('\\' + path.sep, 'g'), '/');
+          var withoutLineNumbers = withoutPathSep.replace(/:\d+:\d+/g, ':$LINE:$COL');
           var withoutNestedLineNumbers = withoutLineNumbers.replace(/, \<anonymous\>:\$LINE:\$COL\)$/, ')');
           return withoutNestedLineNumbers;
       }


### PR DESCRIPTION
unit tests fail on windows, because they expect e.g.:
            at: Test.<anonymous> ($TEST\undef.js:$LINE:$COL)
but get 
            at: Test.<anonymous> ($TEST/undef.js:$LINE:$COL)