### PR TITLE
Fix #105: only use one test runner for results, even if multiple streams are created

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -24,6 +24,7 @@ function Results () {
     this._stream = through();
     this.tests = [];
     this._only = null;
+    this._isRunning = false;
 }
 
 Results.prototype.createStream = function (opts) {
@@ -65,14 +66,17 @@ Results.prototype.createStream = function (opts) {
         self._stream.pipe(output);
     }
 
-    nextTick(function next() {
-        var t;
-        while (t = getNextTest(self)) {
-            t.run();
-            if (!t.ended) return t.once('end', function(){ nextTick(next); });
-        }
-        self.emit('done');
-    });
+    if (!this._isRunning) {
+        this._isRunning = true;
+        nextTick(function next() {
+            var t;
+            while (t = getNextTest(self)) {
+                t.run();
+                if (!t.ended) return t.once('end', function(){ nextTick(next); });
+            }
+            self.emit('done');
+        });
+    }
 
     return output;
 };

--- a/test/create_multiple_streams.js
+++ b/test/create_multiple_streams.js
@@ -1,0 +1,31 @@
+var tape = require('../');
+
+tape.test('createMultipleStreams', function(tt) {
+    tt.plan(2);
+
+    var th = tape.createHarness();
+    th.createStream()
+    th.createStream()
+
+    var testOneComplete = false;
+
+    th('test one', function (tht) {
+        tht.plan(1);
+        setTimeout( function() {
+            tht.pass();
+            testOneComplete = true;
+        }, 100);
+    });
+
+    th('test two', function (tht) {
+        tht.ok(testOneComplete, 'test 1 completed before test 2');
+        tht.end();
+    });
+
+    th.onFinish(function() {
+        tt.equal(th._results.count, 2, "harness test ran");
+        tt.equal(th._results.fail,  0, "harness test didn't fail");
+    });
+});
+
+


### PR DESCRIPTION
Fixes https://github.com/substack/tape/issues/105