### PR TITLE
Add "onFailure" listener to test harness.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ exports = module.exports = (function () {
     lazyLoad.onFinish = function () {
         return getHarness().onFinish.apply(this, arguments);
     };
+    
+    lazyLoad.onFailure = function() {
+        return getHarness().onFailure.apply(this, arguments);
+    };
 
     lazyLoad.getHarness = getHarness
 
@@ -133,6 +137,10 @@ function createHarness (conf_) {
 
     test.onFinish = function (cb) {
         results.on('done', cb);
+    };
+
+    test.onFailure = function (cb) {
+        results.on('fail', cb);
     };
     
     var only = false;

--- a/lib/results.js
+++ b/lib/results.js
@@ -104,7 +104,10 @@ Results.prototype._watch = function (t) {
         self.count ++;
 
         if (res.ok) self.pass ++
-        else self.fail ++
+        else {
+            self.fail ++;
+            self.emit('fail');
+        }
     });
     
     t.on('test', function (st) { self._watch(st) });

--- a/readme.markdown
+++ b/readme.markdown
@@ -162,6 +162,10 @@ Generate a new test that will be skipped over.
 The onFinish hook will get invoked when ALL tape tests have finished
 right before tape is about to print the test summary.
 
+## test.onFailure(fn)
+
+The onFailure hook will get invoked whenever any tape tests has failed.
+
 ## t.plan(n)
 
 Declare that `n` assertions should be run. `t.end()` will be called

--- a/test/onFailure.js
+++ b/test/onFailure.js
@@ -1,0 +1,21 @@
+var tap = require("tap");
+var tape = require("../").createHarness();
+
+//Because this test passing depends on a failure,
+//we must direct the failing output of the inner test
+var noop = function(){}
+var mockSink = {on:noop, removeListener:noop, emit:noop, end:noop}
+tape.createStream().pipe(mockSink);
+
+tap.test("on failure", { timeout: 1000 }, function(tt) {
+    tt.plan(1);
+
+    tape("dummy test", function(t) {
+        t.fail();
+        t.end();
+    });
+
+    tape.onFailure(function() {
+        tt.pass("tape ended");
+    });
+});


### PR DESCRIPTION
Adds an onFinish listener to test harness as discussed here: https://github.com/substack/tape/issues/367#issuecomment-303785660