### PR TITLE
add alias 'notDeepEquals' to 'notDeepEqual' function

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -456,6 +456,7 @@ function notDeepEqual(a, b, msg, extra) {
     });
 }
 Test.prototype.notDeepEqual
+= Test.prototype.notDeepEquals
 = Test.prototype.notEquivalent
 = Test.prototype.notDeeply
 = Test.prototype.notSame

--- a/readme.markdown
+++ b/readme.markdown
@@ -241,7 +241,7 @@ Assert that `actual` and `expected` do not have the same structure and nested va
 [node's deepEqual() algorithm](https://github.com/substack/node-deep-equal)
 with strict comparisons (`===`) on leaf nodes and an optional description of the assertion `msg`.
 
-Aliases: `t.notEquivalent()`, `t.notDeeply()`, `t.notSame()`,
+Aliases: `t.notDeepEquals`, `t.notEquivalent()`, `t.notDeeply()`, `t.notSame()`,
 `t.isNotDeepEqual()`, `t.isNotDeeply()`, `t.isNotEquivalent()`,
 `t.isInequivalent()`
 


### PR DESCRIPTION
This is just a small cosmetic update, but in my opinion, if there is alias `deepEquals` (with the **s** at the end) for function `deepEqual`, there should also be alias `notDeepEquals` for `notDeepEqual` function. Not that there is already not enought of aliases for that function, but I would add it there just to keep consistency.