### PR TITLE
[New] use `process.env.NODE_TAPE_OBJECT_PRINT_DEPTH` for the default object print depth

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -8,6 +8,7 @@ var trim = require('string.prototype.trim');
 var bind = require('function-bind');
 var forEach = require('for-each');
 var isEnumerable = bind.call(Function.call, Object.prototype.propertyIsEnumerable);
+var toLowerCase = bind.call(Function.call, String.prototype.toLowerCase);
 
 module.exports = Test;
 
@@ -52,11 +53,22 @@ function Test (name_, opts_, cb_) {
     this.pendingCount = 0;
     this._skip = args.opts.skip || false;
     this._timeout = args.opts.timeout;
-    this._objectPrintDepth = args.opts.objectPrintDepth || 5;
     this._plan = undefined;
     this._cb = args.cb;
     this._progeny = [];
     this._ok = true;
+    var depthEnvVar = process.env.NODE_TAPE_OBJECT_PRINT_DEPTH;
+    if (args.opts.objectPrintDepth) {
+        this._objectPrintDepth = args.opts.objectPrintDepth;
+    } else if (depthEnvVar) {
+        if (toLowerCase(depthEnvVar) === 'infinity') {
+            this._objectPrintDepth = Infinity;
+        } else {
+            this._objectPrintDepth = depthEnvVar;
+        }
+    } else {
+        this._objectPrintDepth = 5;
+    }
 
     for (var prop in this) {
         this[prop] = (function bind(self, val) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -148,8 +148,9 @@ Available `opts` options are:
 - opts.timeout = 500. Set a timeout for the test, after which it will fail.
   See test.timeoutAfter.
 - opts.objectPrintDepth = 5. Configure max depth of expected / actual object
-  printing.
-  
+  printing. Environmental variable `NODE_TAPE_OBJECT_PRINT_DEPTH` can set the
+  desired default depth for all tests; locally-set values will take precedence.
+
 If you forget to `t.plan()` out how many assertions you are going to run and you
 don't call `t.end()` explicitly, your test will hang.
 


### PR DESCRIPTION
Issue #419 