### PR TITLE
Set property '_isOnly' on t object when test.only

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -86,6 +86,7 @@ Results.prototype.push = function (t) {
 
 Results.prototype.only = function (t) {
     this._only = t;
+    t._isOnly = true; 
 };
 
 Results.prototype._watch = function (t) {

--- a/test/only6.js
+++ b/test/only6.js
@@ -1,0 +1,6 @@
+var test = require('../');
+
+test.only('only6 _isOnly property', function (t) {
+    t.ok(t._isOnly);
+    t.end();
+});


### PR DESCRIPTION
Did not see any existing way to check this - so I just added this commit which sets t._isOnly = true if inside a test.only function

Useful for doing conditional stuff if running a given test in isolation; for example some database spinup/teardown or  data structure scenario that should be filled in that would otherwise be there if all tests were run. 
