### PR TITLE
Add tap-react-browser

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -15,10 +15,10 @@ var test = require('tape');
 
 test('timing test', function (t) {
     t.plan(2);
-    
+
     t.equal(typeof Date.now, 'function');
     var start = Date.now();
-    
+
     setTimeout(function () {
         t.equal(Date.now() - start, 100);
     }, 100);
@@ -114,6 +114,7 @@ that will output something pretty if you pipe TAP into them:
  - https://github.com/zoubin/tap-summary
  - https://github.com/Hypercubed/tap-markdown
  - https://github.com/gabrielcsapo/tap-html
+ - https://github.com/mcnuttandrew/tap-react-browser
 
 To use them, try `node test/index.js | tap-spec` or pipe it into one
 of the modules of your choice!
@@ -191,7 +192,7 @@ Generate a passing assertion with a message `msg`.
 Automatically timeout the test after X ms.
 
 ## t.skip(msg)
- 
+
 Generate an assertion that will be skipped over.
 
 ## t.ok(value, msg)


### PR DESCRIPTION
First things first: Tape is a wonderful library, a++++, thank you for building it. 

I would like to add my own tap reporter type thing to the list of reporters, tap-react-browser. As the name would suggest [tap-react-browser](https://www.npmjs.com/package/tap-react-browser) is a component library for doing in browser testing with react+tape. It enables promisification of tests, but allows you to opt out. It plays nice with embedding components. I wasn't sure if it fit into tap reporters or other, so I went with other? But I welcome any feedback.