### PR TITLE
Bugfix function name parsing in stacktrace

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -282,7 +282,7 @@ Test.prototype._assert = function assert (ok, opts) {
 
             // Function call description may not (just) be a function name.
             // Try to extract function name by looking at first "word" only.
-            res.functionName = callDescription.split(/s+/)[0]
+            res.functionName = callDescription.split(/\s+/)[0]
             res.file = filePath;
             res.line = Number(m[3]);
             if (m[4]) res.column = Number(m[4]);

--- a/test/stackTrace.js
+++ b/test/stackTrace.js
@@ -68,6 +68,42 @@ tap.test('preserves stack trace with newlines', function (tt) {
     });
 });
 
+tap.test('parses function name from original stack', function (tt) {
+    tt.plan(1);
+
+    var test = tape.createHarness();
+    test.createStream();
+
+    test._results._watch = function (t) {
+        t.on('result', function (res) {
+            tt.equal('Test.testFunctionNameParsing', res.functionName)
+        });
+    };
+
+    test('t.equal stack trace', function testFunctionNameParsing(t) {
+        t.equal(true, false, 'true should be false');
+        t.end();
+    });
+});
+
+tap.test('parses function name from original stack for anonymous function', function (tt) {
+    tt.plan(1);
+
+    var test = tape.createHarness();
+    test.createStream();
+
+    test._results._watch = function (t) {
+        t.on('result', function (res) {
+            tt.equal('Test.<anonymous>', res.functionName)
+        });
+    };
+
+    test('t.equal stack trace', function (t) {
+        t.equal(true, false, 'true should be false');
+        t.end();
+    });
+});
+
 tap.test('preserves stack trace for failed assertions', function (tt) {
     tt.plan(6);
 


### PR DESCRIPTION
@ljharb @substack:

The functionName parsing logic has a typo (since bf5a750937df4920ab9e2e965be02ac69dd43f72):

```javascript
// this will split on one or more occurrences of the letter 's'
res.functionName = callDescription.split(/s+/)[0]
```

Changed it to split on `/\s+/` instead.

Also cleaned up trailing whitespaces in the penultimate commit. That part is optional, but why not?