### PR TITLE
Fail a test if its callback returns a promise that rejects

### DIFF
--- a/test/promise_fail.js
+++ b/test/promise_fail.js
@@ -1,0 +1,93 @@
+var tap = require('tap');
+var path = require('path');
+var spawn = require('child_process').spawn;
+var concat = require('concat-stream');
+
+var stripFullStack = require('./common').stripFullStack;
+
+tap.test('callback returning rejected promise should cause that test (and only that test) to fail', function (tt) {
+    tt.plan(1);
+
+    var ps = spawn(process.execPath, [path.join(__dirname, 'promises', 'fail.js')]);
+
+    ps.stdout.pipe(concat(function (rows) {
+        var rowsString = rows.toString('utf8');
+
+        if (/^skip\n$/.test(rowsString)) {
+            return tt.pass('the test file indicated it should be skipped');
+        }
+
+        strippedString = stripFullStack(rowsString);
+
+        // hack for consistency across all versions of node
+        // some versions produce a longer stack trace for some reason
+        // since this doesn't affect the validity of the test, the extra line is removed if present
+        // the regex just removes the lines "at <anonymous>" and "[... stack stripped ...]" if they occur together
+        strippedString = strippedString.replace(/.+at <anonymous>\n.+\[\.\.\. stack stripped \.\.\.\]\n/, '');
+
+        tt.same(strippedString, [
+            'TAP version 13',
+            '# promise',
+            'not ok 1 Error: rejection message',
+            '  ---',
+            '    operator: fail',
+            '    stack: |-',
+            '      Error: Error: rejection message',
+            '          [... stack stripped ...]',
+            '  ...',
+            '# after',
+            'ok 2 should be truthy',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  1',
+            '# fail  1',
+            '',
+            ''
+        ].join('\n'));
+    }));
+});
+
+tap.test('subtest callback returning rejected promise should cause that subtest (and only that subtest) to fail', function (tt) {
+    tt.plan(1);
+
+    var ps = spawn(process.execPath, [path.join(__dirname, 'promises', 'subTests.js')]);
+
+    ps.stdout.pipe(concat(function (rows) {
+        var rowsString = rows.toString('utf8');
+
+        if (/^skip\n$/.test(rowsString)) {
+            return tt.pass('the test file indicated it should be skipped');
+        }
+
+        strippedString = stripFullStack(rowsString);
+
+        // hack for consistency across all versions of node
+        // some versions produce a longer stack trace for some reason
+        // since this doesn't affect the validity of the test, the extra line is removed if present
+        // the regex just removes the lines "at <anonymous>" and "[... stack stripped ...]" if they occur together
+        strippedString = strippedString.replace(/.+at <anonymous>\n.+\[\.\.\. stack stripped \.\.\.\]\n/, '');
+
+        tt.same(strippedString, [
+            'TAP version 13',
+            '# promise',
+            '# sub test that should fail',
+            'not ok 1 Error: rejection message',
+            '  ---',
+            '    operator: fail',
+            '    stack: |-',
+            '      Error: Error: rejection message',
+            '          [... stack stripped ...]',
+            '  ...',
+            '# sub test that should pass',
+            'ok 2 should be truthy',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  1',
+            '# fail  1',
+            '',
+            ''
+        ].join('\n'));
+    }));
+});

--- a/test/promises/fail.js
+++ b/test/promises/fail.js
@@ -1,0 +1,17 @@
+var test = require('../../');
+
+if (typeof Promise === 'function' && typeof Promise.resolve === 'function') {
+    test('promise', function (t) {
+        return new Promise(function (resolve, reject) {
+            reject(new Error('rejection message'));
+        });
+    });
+
+    test('after', function (t) {
+        t.plan(1);
+        t.ok(true);
+    });
+} else {
+    // if promises aren't supported pass the node-tap test
+    console.log('skip');
+}

--- a/test/promises/subTests.js
+++ b/test/promises/subTests.js
@@ -1,0 +1,18 @@
+var test = require('../../');
+
+if (typeof Promise === 'function' && typeof Promise.resolve === 'function') {
+    test('promise', function (t) {
+        t.test('sub test that should fail', function (t) {
+            return new Promise(function (resolve, reject) {
+                reject(new Error('rejection message'));
+            });
+        });
+        t.test('sub test that should pass', function (t) {
+            t.plan(1);
+            t.ok(true);
+        });
+    });
+} else {
+    // if promises aren't supported pass the node-tap test
+    console.log('skip');
+}


### PR DESCRIPTION
This is mentioned here https://github.com/substack/tape/issues/208#issuecomment-313244971

The benefit is that you can use async functions as the test callback without unexpected results like hanging with no output in the browser.

If the global variable `Promise` isn't defined, then nothing is changed.