### PR TITLE
Add link to mixed-tape (tape with concurrency support)

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -131,6 +131,7 @@ By default, uncaught exceptions in your tests will not be intercepted, and will 
 - ES6 support with https://www.npmjs.com/package/babel-tape-runner or https://www.npmjs.com/package/buble-tape-runner
 - Different test syntax with https://github.com/pguth/flip-tape (warning: mutates String.prototype)
 - Electron test runner with https://github.com/tundrax/electron-tap
+- Concurrency support with https://github.com/imsnif/mixed-tape
 
 # methods
 


### PR DESCRIPTION
Hey, I created a small wrapper for tape that adds concurrency support (same thread, just running tests asynchronously). I hope others will find it useful.