### PR TITLE
Adding tap-junit to Readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -115,6 +115,7 @@ that will output something pretty if you pipe TAP into them:
 - [tap-markdown](https://github.com/Hypercubed/tap-markdown)
 - [tap-html](https://github.com/gabrielcsapo/tap-html)
 - [tap-react-browser](https://github.com/mcnuttandrew/tap-react-browser)
+- [tap-junit](https://github.com/dhershman1/tap-junit)
 
 To use them, try `node test/index.js | tap-spec` or pipe it into one
 of the modules of your choice!


### PR DESCRIPTION
It was brought to my attention to add my tap-junit module to the list. I've done so here (And hopefully in the right spot)

tap-junit is a lot like tap-xunit in a sense.

It's small lightweight and pretty easy to use. I will happily address any questions/concerns! Thanks!