### PR TITLE
Clarify doesNotThrow parameters

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -266,7 +266,7 @@ Assert that the function call `fn()` throws an exception. `expected`, if present
 
 ## t.doesNotThrow(fn, expected, msg)
 
-Assert that the function call `fn()` does not throw an exception. `msg` is an optional description of the assertion.
+Assert that the function call `fn()` does not throw an exception. `expected`, if present, limits what should not be thrown. For example, set `expected` to `/user/` to fail the test only if the string representation of the exception contains the word `user`. Any other exception would pass the test. If `expected` is omitted, any exception will fail the test. `msg` is an optional description of the assertion.
 
 ## t.test(name, [opts], cb)
 


### PR DESCRIPTION
To prevent issues like #334, here is a proposal to clarify the purpose of the second argument. My own first reaction to the second argument was like "Whaaat, the docs cannot be right. Even the mere word 'expected' is against the purpose of the assertion. How we can expect something that is not thrown. The argument cannot have any meaning." Then I browsed through the issues, found #334 and then it became clear.