### PR TITLE
Add -i flag to ignore tests inside node_module directories

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -4,13 +4,15 @@
 
 var resolveModule = require('resolve').sync;
 var resolvePath = require('path').resolve;
+var readFileSync = require('fs').readFileSync;
 var parseOpts = require('minimist');
 var glob = require('glob');
+var ignore = require('dotignore');
 
 var opts = parseOpts(process.argv.slice(2), {
-    alias: { r: 'require' },
-    string: 'require',
-    default: { r: [] }
+    alias: { r: 'require', i: 'ignore' },
+    string: ['require', 'ignore'],
+    default: { r: [], i: null }
 });
 
 var cwd = process.cwd();
@@ -29,6 +31,16 @@ opts.require.forEach(function (module) {
     }
 });
 
+if (typeof opts.ignore === 'string') {
+    try {
+        var ignoreStr = readFileSync(resolvePath(cwd, opts.ignore || '.gitignore'), 'utf-8');
+    } catch (e) {
+        console.error(e.message);
+        process.exit(2);
+    }
+    var matcher = ignore.createMatcher(ignoreStr);
+}
+
 opts._.forEach(function (arg) {
     // If glob does not match, `files` will be an empty array.
     // Note: `glob.sync` may throw an error and crash the node process.
@@ -38,7 +50,7 @@ opts._.forEach(function (arg) {
         throw new TypeError('unknown error: glob.sync did not return an array or throw. Please report this.');
     }
 
-    files.forEach(function (file) {
+    files.filter(function (file) { return !matcher || !matcher.shouldIgnore(file); }).forEach(function (file) {
         require(resolvePath(cwd, file));
     });
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dependencies": {
         "deep-equal": "^2.0.1",
         "defined": "^1.0.0",
+        "dotignore": "^0.1.2",
         "for-each": "^0.3.3",
         "function-bind": "^1.1.1",
         "glob": "^7.1.6",

--- a/test/ignore/.ignore
+++ b/test/ignore/.ignore
@@ -1,0 +1,1 @@
+fake_node_modules

--- a/test/ignore/fake_node_modules/stub1.js
+++ b/test/ignore/fake_node_modules/stub1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+    t.plan(1);
+    t.fail('Should not print');
+});

--- a/test/ignore/fake_node_modules/stub2.js
+++ b/test/ignore/fake_node_modules/stub2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+    t.fail('Should not print');
+    t.end();
+});

--- a/test/ignore/test.js
+++ b/test/ignore/test.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../');
+
+tape.test(function (t) {
+    t.plan(1);
+    t.ok('Okay');
+});

--- a/test/ignore/test/stub1.js
+++ b/test/ignore/test/stub1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+    t.plan(1);
+    t.pass('test/stub1');
+});

--- a/test/ignore/test/stub2.js
+++ b/test/ignore/test/stub2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+    t.pass('test/stub2');
+    t.end();
+});

--- a/test/ignore/test/sub/sub.stub1.js
+++ b/test/ignore/test/sub/sub.stub1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../../');
+
+tape.test(function (t) {
+    t.plan(1);
+    t.pass('test/sub/stub1');
+});

--- a/test/ignore/test/sub/sub.stub2.js
+++ b/test/ignore/test/sub/sub.stub2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../../');
+
+tape.test(function (t) {
+    t.pass('test/sub/stub2');
+    t.end();
+});

--- a/test/ignore/test2.js
+++ b/test/ignore/test2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../');
+
+tape.test(function (t) {
+    t.pass('Should print');
+    t.end();
+});

--- a/test/ignore_from_gitignore.js
+++ b/test/ignore_from_gitignore.js
@@ -1,0 +1,122 @@
+'use strict';
+
+var tap = require('tap');
+var path = require('path');
+var spawn = require('child_process').spawn;
+var concat = require('concat-stream');
+
+var stripFullStack = require('./common').stripFullStack;
+
+var tapeBin = path.join(process.cwd(), 'bin/tape');
+
+tap.test('Should pass with ignoring', { skip: process.platform === 'win32' }, function (tt) {
+    tt.plan(2);
+
+    var tc = function (rows) {
+        tt.same(stripFullStack(rows.toString('utf8')), [
+            'TAP version 13',
+            '# (anonymous)',
+            'ok 1 should be truthy',
+            '# (anonymous)',
+            'ok 2 test/stub1',
+            '# (anonymous)',
+            'ok 3 test/stub2',
+            '# (anonymous)',
+            'ok 4 test/sub/stub1',
+            '# (anonymous)',
+            'ok 5 test/sub/stub2',
+            '# (anonymous)',
+            'ok 6 Should print',
+            '',
+            '1..6',
+            '# tests 6',
+            '# pass  6',
+            '',
+            '# ok',
+            '',
+            ''
+        ].join('\n'));
+    };
+
+    var ps = spawn(tapeBin, ['**/*.js', '-i', '.ignore'], {cwd: path.join(__dirname, 'ignore')});
+    ps.stdout.pipe(concat(tc));
+    ps.on('exit', function (code) {
+        tt.equal(code, 0); // code 0
+    });
+});
+
+tap.test('Should pass', { skip: process.platform === 'win32' }, function (tt) {
+    tt.plan(2);
+
+    var tc = function (rows) {
+        tt.same(stripFullStack(rows.toString('utf8')), [
+            'TAP version 13',
+            '# (anonymous)',
+            'not ok 1 Should not print',
+            '  ---',
+            '    operator: fail',
+            '    at: Test.<anonymous> ($TEST/ignore/fake_node_modules/stub1.js:$LINE:$COL)',
+            '    stack: |-',
+            '      Error: Should not print',
+            '          [... stack stripped ...]',
+            '          at Test.<anonymous> ($TEST/ignore/fake_node_modules/stub1.js:$LINE:$COL)',
+            '          [... stack stripped ...]',
+            '  ...',
+            '# (anonymous)',
+            'not ok 2 Should not print',
+            '  ---',
+            '    operator: fail',
+            '    at: Test.<anonymous> ($TEST/ignore/fake_node_modules/stub2.js:$LINE:$COL)',
+            '    stack: |-',
+            '      Error: Should not print',
+            '          [... stack stripped ...]',
+            '          at Test.<anonymous> ($TEST/ignore/fake_node_modules/stub2.js:$LINE:$COL)',
+            '          [... stack stripped ...]',
+            '  ...',
+            '# (anonymous)',
+            'ok 3 should be truthy',
+            '# (anonymous)',
+            'ok 4 test/stub1',
+            '# (anonymous)',
+            'ok 5 test/stub2',
+            '# (anonymous)',
+            'ok 6 test/sub/stub1',
+            '# (anonymous)',
+            'ok 7 test/sub/stub2',
+            '# (anonymous)',
+            'ok 8 Should print',
+            '',
+            '1..8',
+            '# tests 8',
+            '# pass  6',
+            '# fail  2',
+            '',
+            ''
+        ].join('\n'));
+    };
+
+    var ps = spawn(tapeBin, ['**/*.js'], {cwd: path.join(__dirname, 'ignore')});
+    ps.stdout.pipe(concat(tc));
+    ps.on('exit', function (code) {
+        tt.equal(code, 1);
+    });
+});
+
+tap.test('Should fail when ignore file does not exist', { skip: process.platform === 'win32' }, function (tt) {
+    tt.plan(3);
+
+    var testStdout = function (rows) {
+        tt.same(rows.toString('utf8'), '');
+    };
+
+    var testStderr = function (rows) {
+        tt.ok(/^ENOENT[:,] no such file or directory,? (?:open )?'\$TEST\/ignore\/.gitignore'\n$/m.test(stripFullStack(rows.toString('utf8'))));
+    };
+
+    var ps = spawn(tapeBin, ['**/*.js', '-i'], {cwd: path.join(__dirname, 'ignore')});
+    ps.stdout.pipe(concat(testStdout));
+    ps.stderr.pipe(concat(testStderr));
+    ps.on('exit', function (code) {
+        tt.equal(code, 2);
+    });
+});


### PR DESCRIPTION
This will partly resolve #428 by adding the -i flag to ignore any tests inside node_module directories to allow co-locating tests with their modules. Running `tape **/*.spec.js -i` in the project directory won't execute tests inside its npm packages that may break the tape run due different testing frameworks etc.