### PR TITLE
Add `opts.autoclose` in `test.createStream()` #465

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ exports = module.exports = (function () {
         if (!opts) opts = {};
         if (!harness) {
             var output = through();
-            getHarness({ stream: output, objectMode: opts.objectMode });
+            getHarness({ stream: output, objectMode: opts.objectMode, autoclose: opts.autoclose });
             return output;
         }
         return harness.createStream(opts);
@@ -50,7 +50,7 @@ exports = module.exports = (function () {
 
     function getHarness(opts) {
         if (!opts) opts = {};
-        opts.autoclose = !canEmitExit;
+        opts.autoclose = opts.autoclose || !canEmitExit;
         if (!harness) harness = createExitHarness(opts);
         return harness;
     }
@@ -106,7 +106,7 @@ function createHarness(conf_) {
     if (!conf_) conf_ = {};
     var results = createResult();
     if (conf_.autoclose !== false) {
-        results.once('done', function () { results.close() });
+        results.once('done', function () { if (!results.closed) results.close() });
     }
 
     var test = function (name, conf, cb) {
@@ -151,7 +151,7 @@ function createHarness(conf_) {
     };
     test._exitCode = 0;
 
-    test.close = function () { results.close() };
+    test.close = function () { if (!results.closed) results.close() };
 
     return test;
 }

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ exports = module.exports = (function () {
 
     function getHarness(opts) {
         if (!opts) opts = {};
-        opts.autoclose = opts.autoclose || !canEmitExit;
+        opts.autoclose = typeof opts.autoclose === 'boolean' ? opts.autoclose : !canEmitExit;
         if (!harness) harness = createExitHarness(opts);
         return harness;
     }


### PR DESCRIPTION
> Tries to solve #465 

### Problem
The stream created inside `results` was being closed only when the process was exiting. Changed the API to introduce `opts.autoclose` that is provisioned over `canEmitExit` so that results get closed when the results are `done`. In normal usage(from command line) harness closes on process end.

`autoclose` is required beacause `through`s queue method is storing the results untill the end where it is `end`ed only when harness is closed.

### Normal usage
``` js
const tapSpec = require('tap-spec');
const {add, divide} = require('../index.js');
const test = require('./tape/index.js');

// piping programatically
test.createStream()
  .pipe(tapSpec())
  .pipe(process.stdout);

test('should add', t => {
  t.equal(add(3, 4), 7);
  t.end();
});

test('should divide', t => {
  t.equal(divide(8, 2), 4);
  t.end();
});
```
we get the output:
```
> node test/test.js

  should add

    √ should be equal

  should divide

    √ should be equal
```
### `opts.autoclose` set to true
``` js
test.createStream({
  autoclose: true,
})
  .pipe(tapSpec())
  .pipe(process.stdout);
```
we get
```
> node test/test.js

  should add

    √ should be equal

  should divide

    √ should be equal

  total:     2
  passing:   2
  duration:  43ms
```