### PR TITLE
Add badge for usage examples for this module on Codota

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -5,6 +5,7 @@ tap-producing test harness for node and browsers
 [![browser support](https://ci.testling.com/substack/tape.png)](http://ci.testling.com/substack/tape)
 
 [![build status](https://secure.travis-ci.org/substack/tape.svg?branch=master)](http://travis-ci.org/substack/tape)
+[![usage exapmples](https://img.shields.io/badge/usage%20examples-available-brightgreen.svg)](https://www.codota.com/code/javascript/modules/tape)
 
 ![tape](https://web.archive.org/web/20170612184731if_/http://substack.net/images/tape_drive.png)
 


### PR DESCRIPTION
This simple PR just adds a shield that links to [usage examples for tape on Codota, as available on GitHub](https://www.codota.com/code/javascript/modules/tape). It is possible to get examples for each individual method as listed on the right-hand side of the linked web page. I believe this will be valuable for new users who want to learn to use this module by examining examples from other projects.
Feedback welcome. If you like it, I can also link to examples for individual methods in the readme in a separate PR.

Here's a screenshot of how the change looks when viewing this readme markdown: 
![image](https://user-images.githubusercontent.com/1917767/57258851-51a12080-7066-11e9-9765-2cfa7054e9d8.png)
