### PR TITLE
[fix] don't consider 'ok' of todo tests in exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function createHarness(conf_) {
                 inspectCode(st_);
             });
             st.on('result', function (r) {
-                if (!r.ok && typeof r !== 'string') test._exitCode = 1
+                if (!r.todo && !r.ok && typeof r !== 'string') test._exitCode = 1
             });
         })(t);
 

--- a/test/todo_single.js
+++ b/test/todo_single.js
@@ -1,0 +1,37 @@
+var tap = require('tap');
+var tape = require('../');
+var concat = require('concat-stream');
+
+var common = require('./common');
+var stripFullStack = common.stripFullStack;
+
+tap.test('tape todo test', function (assert) {
+    var test = tape.createHarness({ exit: false });
+    assert.plan(1);
+
+    test.createStream().pipe(concat(function (body) {
+        assert.equal(
+            stripFullStack(body.toString('utf8')),
+            'TAP version 13\n'
+            + '# failure\n'
+            + 'not ok 1 should be equal # TODO\n'
+            + '  ---\n'
+            + '    operator: equal\n'
+            + '    expected: false\n'
+            + '    actual:   true\n'
+            + '    at: Test.<anonymous> ($TEST/todo_single.js:$LINE:$COL)\n'
+            + '  ...\n'
+            + '\n'
+            + '1..1\n'
+            + '# tests 1\n'
+            + '# pass  1\n'
+            + '\n'
+            + '# ok\n'
+        )
+    }));
+
+    test('failure', { todo: true }, function (t) {
+        t.equal(true, false);
+        t.end();
+    });
+});


### PR DESCRIPTION
Fixes #469 

`result.ok` not being considered towards exitcode if `result.todo` is true