### PR TITLE
[Breaking] support passing in an async function for the test callback

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,4 +8,12 @@
             "named": "never",
         }],
     },
+    "overrides": [
+        {
+            "files": ["test/async-await/*"],
+            "parserOptions": {
+                "ecmaVersion": 2017,
+            },
+        },
+    ],
 }

--- a/lib/test.js
+++ b/lib/test.js
@@ -91,7 +91,23 @@ Test.prototype.run = function () {
     if (this._timeout != null) {
         this.timeoutAfter(this._timeout);
     }
-    this._cb(this);
+
+    var callbackReturn = this._cb(this);
+
+    if (
+        typeof Promise === 'function' &&
+        callbackReturn &&
+        typeof callbackReturn.then === 'function' &&
+        typeof callbackReturn.catch === 'function'
+    ) {
+        callbackReturn.catch(function onError(err) {
+            nextTick(function rethrowError() {
+                throw err
+            })
+        })
+        return
+    }
+
     this.emit('run');
 };
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -97,15 +97,18 @@ Test.prototype.run = function () {
     if (
         typeof Promise === 'function' &&
         callbackReturn &&
-        typeof callbackReturn.then === 'function' &&
-        typeof callbackReturn.catch === 'function'
+        typeof callbackReturn.then === 'function'
     ) {
-        callbackReturn.catch(function onError(err) {
-            nextTick(function rethrowError() {
-                throw err
-            })
-        })
-        return
+        var self = this;
+        Promise.resolve(callbackReturn).then(function onResolve() {
+            if (!self.calledEnd) {
+                self.end();
+            }
+        }).catch(function onError(err) {
+            self.fail(err);
+            self.end();
+        });
+        return;
     }
 
     this.emit('run');

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -128,11 +128,10 @@ tap.test('async5', function (t) {
             'ok 4 after request',
             'ok 5 should be equal',
             'ok 6 should be equal',
-            'ok 7 undefined',
             '',
-            '1..7',
-            '# tests 7',
-            '# pass  7',
+            '1..6',
+            '# tests 6',
+            '# pass  6',
             '',
             '# ok'
         ].join('\n') + '\n\n');
@@ -190,7 +189,20 @@ tap.test('async-error', function (t) {
             'TAP version 13',
             '# async-error',
             'ok 1 before throw',
-            ''
+            'not ok 2 Error: oopsie',
+            '  ---',
+            '    operator: fail',
+            '    stack: |-',
+            '      Error: Error: oopsie',
+            '          [... stack stripped ...]',
+            '  ...',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  1',
+            '# fail  1',
+            '',
+            '',
         ].join('\n'));
         t.same(r.exitCode, 1);
 
@@ -203,18 +215,7 @@ tap.test('async-error', function (t) {
         });
         stderr = lines.join('\n');
 
-        t.same(stripFullStack(stderr), [
-            '$TAPE/lib/test.js:106',
-            '                throw err',
-            '                ^',
-            '',
-            'Error: oopsie',
-            '    at Test.myTest ($TEST/async-await/async-error.js:$LINE:$COL)',
-            '    at Test.bound [as _cb] ($TAPE/lib/test.js:$LINE:$COL)',
-            '    at Test.run ($TAPE/lib/test.js:$LINE:$COL)',
-            '    at Test.bound [as run] ($TAPE/lib/test.js:$LINE:$COL)',
-            ''
-        ].join('\n'));
+        t.same(stderr, '');
         t.end();
     });
 });

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -119,7 +119,7 @@ tap.test('async4', function (t) {
 
 tap.test('async5', function (t) {
     runProgram('async-await', 'async5.js', function (r) {
-        t.same(r.stdout.toString('utf8'), [
+        t.same(stripFullStack(r.stdout.toString('utf8')), [
             'TAP version 13',
             '# async5',
             'ok 1 before server',
@@ -128,14 +128,24 @@ tap.test('async5', function (t) {
             'ok 4 after request',
             'ok 5 should be equal',
             'ok 6 should be equal',
+            'ok 7 undefined',
+            'not ok 8 .end() called twice',
+            '  ---',
+            '    operator: fail',
+            '    at: Server.<anonymous> ($TEST/async-await/async5.js:$LINE:$COL)',
+            '    stack: |-',
+            '      Error: .end() called twice',
+            '          [... stack stripped ...]',
+            '          at Server.<anonymous> ($TEST/async-await/async5.js:$LINE:$COL)',
+            '          [... stack stripped ...]',
+            '  ...',
             '',
-            '1..6',
-            '# tests 6',
-            '# pass  6',
-            '',
-            '# ok'
+            '1..8',
+            '# tests 8',
+            '# pass  7',
+            '# fail  1'
         ].join('\n') + '\n\n');
-        t.same(r.exitCode, 0);
+        t.same(r.exitCode, 1);
         t.same(r.stderr.toString('utf8'), '');
         t.end();
     });

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -1,0 +1,220 @@
+var tap = require('tap');
+
+var stripFullStack = require('./common').stripFullStack;
+var runProgram = require('./common').runProgram;
+
+var nodeVersion = process.versions.node;
+var majorVersion = nodeVersion.split('.')[0];
+
+if (Number(majorVersion) < 8) {
+    process.exit(0);
+}
+
+tap.test('async1', function (t) {
+    runProgram('async-await', 'async1.js', function (r) {
+        t.same(r.stdout.toString('utf8'), [
+            'TAP version 13',
+            '# async1',
+            'ok 1 before await',
+            'ok 2 after await',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  2',
+            '',
+            '# ok'
+        ].join('\n') + '\n\n');
+        t.same(r.exitCode, 0);
+        t.same(r.stderr.toString('utf8'), '');
+        t.end();
+    });
+});
+
+tap.test('async2', function (t) {
+    runProgram('async-await', 'async2.js', function (r) {
+        var stdout = r.stdout.toString('utf8');
+        var lines = stdout.split('\n');
+        lines = lines.filter(function (line) {
+            return ! /^(\s+)at(\s+)<anonymous>$/.test(line);
+        });
+        stdout = lines.join('\n');
+
+        t.same(stripFullStack(stdout), [
+            'TAP version 13',
+            '# async2',
+            'ok 1 before await',
+            'not ok 2 after await',
+            '  ---',
+            '    operator: ok',
+            '    expected: true',
+            '    actual:   false',
+            '    at: Test.myTest ($TEST/async-await/async2.js:$LINE:$COL)',
+            '    stack: |-',
+            '      Error: after await',
+            '          [... stack stripped ...]',
+            '          at Test.myTest ($TEST/async-await/async2.js:$LINE:$COL)',
+            '  ...',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  1',
+            '# fail  1'
+        ].join('\n') + '\n\n');
+        t.same(r.exitCode, 1);
+        t.same(r.stderr.toString('utf8'), '');
+        t.end();
+    });
+});
+
+tap.test('async3', function (t) {
+    runProgram('async-await', 'async3.js', function (r) {
+        t.same(r.stdout.toString('utf8'), [
+            'TAP version 13',
+            '# async3',
+            'ok 1 before await',
+            'ok 2 after await',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  2',
+            '',
+            '# ok'
+        ].join('\n') + '\n\n');
+        t.same(r.exitCode, 0);
+        t.same(r.stderr.toString('utf8'), '');
+        t.end();
+    });
+});
+
+tap.test('async4', function (t) {
+    runProgram('async-await', 'async4.js', function (r) {
+        t.same(stripFullStack(r.stdout.toString('utf8')), [
+            'TAP version 13',
+            '# async4',
+            'ok 1 before await',
+            'not ok 2 Error: oops',
+            '  ---',
+            '    operator: error',
+            '    expected: |-',
+            '      undefined',
+            '    actual: |-',
+            '      [Error: oops]',
+            '    at: Test.myTest ($TEST/async-await/async4.js:$LINE:$COL)',
+            '    stack: |-',
+            '      Error: oops',
+            '          at Timeout.myTimeout [as _onTimeout] ($TEST/async-await/async4.js:$LINE:$COL)',
+            '          [... stack stripped ...]',
+            '  ...',
+            '',
+            '1..2',
+            '# tests 2',
+            '# pass  1',
+            '# fail  1'
+        ].join('\n') + '\n\n');
+        t.same(r.exitCode, 1);
+        t.same(r.stderr.toString('utf8'), '');
+        t.end();
+    });
+});
+
+tap.test('async5', function (t) {
+    runProgram('async-await', 'async5.js', function (r) {
+        t.same(r.stdout.toString('utf8'), [
+            'TAP version 13',
+            '# async5',
+            'ok 1 before server',
+            'ok 2 after server',
+            'ok 3 before request',
+            'ok 4 after request',
+            'ok 5 should be equal',
+            'ok 6 should be equal',
+            'ok 7 undefined',
+            '',
+            '1..7',
+            '# tests 7',
+            '# pass  7',
+            '',
+            '# ok'
+        ].join('\n') + '\n\n');
+        t.same(r.exitCode, 0);
+        t.same(r.stderr.toString('utf8'), '');
+        t.end();
+    });
+});
+
+tap.test('sync-error', function (t) {
+    runProgram('async-await', 'sync-error.js', function (r) {
+        t.same(stripFullStack(r.stdout.toString('utf8')), [
+            'TAP version 13',
+            '# sync-error',
+            'ok 1 before throw',
+            ''
+        ].join('\n'));
+        t.same(r.exitCode, 1);
+
+        var stderr = r.stderr.toString('utf8');
+        var lines = stderr.split('\n');
+        lines = lines.filter(function (line) {
+            return ! /\(timers.js:/.test(line) &&
+                ! /\(internal\/timers.js:/.test(line) &&
+                ! /Immediate\.next/.test(line);
+        });
+        stderr = lines.join('\n');
+
+        t.same(stripFullStack(stderr), [
+            '$TEST/async-await/sync-error.js:5',
+            '    throw new Error(\'oopsie\');',
+            '    ^',
+            '',
+            'Error: oopsie',
+            '    at Test.myTest ($TEST/async-await/sync-error.js:$LINE:$COL)',
+            '    at Test.bound [as _cb] ($TAPE/lib/test.js:$LINE:$COL)',
+            '    at Test.run ($TAPE/lib/test.js:$LINE:$COL)',
+            '    at Test.bound [as run] ($TAPE/lib/test.js:$LINE:$COL)',
+            ''
+        ].join('\n'));
+        t.end();
+    });
+});
+
+tap.test('async-error', function (t) {
+    runProgram('async-await', 'async-error.js', function (r) {
+        var stdout = r.stdout.toString('utf8');
+        var lines = stdout.split('\n');
+        lines = lines.filter(function (line) {
+            return ! /^(\s+)at(\s+)<anonymous>$/.test(line);
+        });
+        stdout = lines.join('\n');
+
+        t.same(stripFullStack(stdout.toString('utf8')), [
+            'TAP version 13',
+            '# async-error',
+            'ok 1 before throw',
+            ''
+        ].join('\n'));
+        t.same(r.exitCode, 1);
+
+        var stderr = r.stderr.toString('utf8');
+        var lines = stderr.split('\n');
+        lines = lines.filter(function (line) {
+            return ! /\(timers.js:/.test(line) &&
+                ! /\(internal\/timers.js:/.test(line) &&
+                ! /Immediate\.next/.test(line);
+        });
+        stderr = lines.join('\n');
+
+        t.same(stripFullStack(stderr), [
+            '$TAPE/lib/test.js:106',
+            '                throw err',
+            '                ^',
+            '',
+            'Error: oopsie',
+            '    at Test.myTest ($TEST/async-await/async-error.js:$LINE:$COL)',
+            '    at Test.bound [as _cb] ($TAPE/lib/test.js:$LINE:$COL)',
+            '    at Test.run ($TAPE/lib/test.js:$LINE:$COL)',
+            '    at Test.bound [as run] ($TAPE/lib/test.js:$LINE:$COL)',
+            ''
+        ].join('\n'));
+        t.end();
+    });
+});

--- a/test/async-await/async-error.js
+++ b/test/async-await/async-error.js
@@ -1,0 +1,8 @@
+var test = require('../../');
+
+test('async-error', async function myTest(t) {
+    t.ok(true, 'before throw');
+    throw new Error('oopsie');
+    t.ok(true, 'after throw');
+    t.end();
+});

--- a/test/async-await/async-error.js
+++ b/test/async-await/async-error.js
@@ -4,5 +4,4 @@ test('async-error', async function myTest(t) {
     t.ok(true, 'before throw');
     throw new Error('oopsie');
     t.ok(true, 'after throw');
-    t.end();
 });

--- a/test/async-await/async1.js
+++ b/test/async-await/async1.js
@@ -7,9 +7,7 @@ test('async1', async function myTest(t) {
             setTimeout(resolve, 10);
         });
         t.ok(true, 'after await');
-        t.end();
     } catch (err) {
         t.ifError(err);
-        t.end();
     }
 });

--- a/test/async-await/async1.js
+++ b/test/async-await/async1.js
@@ -1,0 +1,15 @@
+var test = require('../../');
+
+test('async1', async function myTest(t) {
+    try {
+        t.ok(true, 'before await');
+        await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+        });
+        t.ok(true, 'after await');
+        t.end();
+    } catch (err) {
+        t.ifError(err);
+        t.end();
+    }
+});

--- a/test/async-await/async1.js
+++ b/test/async-await/async1.js
@@ -7,6 +7,7 @@ test('async1', async function myTest(t) {
             setTimeout(resolve, 10);
         });
         t.ok(true, 'after await');
+        t.end();
     } catch (err) {
         t.ifError(err);
     }

--- a/test/async-await/async2.js
+++ b/test/async-await/async2.js
@@ -7,9 +7,7 @@ test('async2', async function myTest(t) {
             setTimeout(resolve, 10);
         });
         t.ok(false, 'after await');
-        t.end();
     } catch (err) {
         t.ifError(err);
-        t.end();
     }
 });

--- a/test/async-await/async2.js
+++ b/test/async-await/async2.js
@@ -1,0 +1,15 @@
+var test = require('../../');
+
+test('async2', async function myTest(t) {
+    try {
+        t.ok(true, 'before await');
+        await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+        });
+        t.ok(false, 'after await');
+        t.end();
+    } catch (err) {
+        t.ifError(err);
+        t.end();
+    }
+});

--- a/test/async-await/async3.js
+++ b/test/async-await/async3.js
@@ -1,0 +1,10 @@
+var test = require('../../');
+
+test('async3', async function myTest(t) {
+    t.ok(true, 'before await');
+    await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+    });
+    t.ok(true, 'after await');
+    t.end();
+});

--- a/test/async-await/async3.js
+++ b/test/async-await/async3.js
@@ -6,5 +6,4 @@ test('async3', async function myTest(t) {
         setTimeout(resolve, 10);
     });
     t.ok(true, 'after await');
-    t.end();
 });

--- a/test/async-await/async4.js
+++ b/test/async-await/async4.js
@@ -1,0 +1,17 @@
+var test = require('../../');
+
+test('async4', async function myTest(t) {
+    try {
+        t.ok(true, 'before await');
+        await new Promise((resolve, reject) => {
+            setTimeout(function myTimeout() {
+                reject(new Error('oops'));
+            }, 10);
+        });
+        t.ok(true, 'after await');
+        t.end();
+    } catch (err) {
+        t.ifError(err);
+        t.end();
+    }
+});

--- a/test/async-await/async4.js
+++ b/test/async-await/async4.js
@@ -9,9 +9,7 @@ test('async4', async function myTest(t) {
             }, 10);
         });
         t.ok(true, 'after await');
-        t.end();
     } catch (err) {
         t.ifError(err);
-        t.end();
     }
 });

--- a/test/async-await/async5.js
+++ b/test/async-await/async5.js
@@ -1,0 +1,57 @@
+var util = require('util');
+var http = require('http');
+
+var test = require('../../');
+
+test('async5', async function myTest(t) {
+    try {
+        t.ok(true, 'before server');
+
+        var mockDb = { state: 'old' };
+        var server = http.createServer(function (req, res) {
+            res.end('OK');
+
+            // Pretend we write to the DB and it takes time.
+            setTimeout(function () {
+                mockDb.state = 'new';
+            }, 10);
+        });
+
+        await util.promisify(function (cb) {
+            server.listen(0, cb);
+        })();
+
+        t.ok(true, 'after server');
+
+        t.ok(true, 'before request');
+
+        var res = await util.promisify(function (cb) {
+            var req = http.request({
+                hostname: 'localhost',
+                port: server.address().port,
+                path: '/',
+                method: 'GET'
+            }, function (res) {
+                cb(null, res);
+            });
+            req.end();
+        })();
+
+        t.ok(true, 'after request');
+
+        res.resume();
+        t.equal(res.statusCode, 200);
+
+        setTimeout(function () {
+            t.equal(mockDb.state, 'new');
+
+            server.close(function (err) {
+                t.ifError(err);
+                t.end();
+            });
+        }, 50);
+    } catch (err) {
+        t.ifError(err);
+        t.end();
+    }
+});

--- a/test/async-await/async5.js
+++ b/test/async-await/async5.js
@@ -42,14 +42,16 @@ test('async5', async function myTest(t) {
         res.resume();
         t.equal(res.statusCode, 200);
 
-        setTimeout(function () {
-            t.equal(mockDb.state, 'new');
+        await new Promise(function (resolve, reject) {
+            setTimeout(function () {
+                t.equal(mockDb.state, 'new');
 
-            server.close(function (err) {
-                t.ifError(err);
-                t.end();
-            });
-        }, 50);
+                server.close(function (err) {
+                    if (err) { reject(err); }
+                    else { resolve(); }
+                });
+            }, 50);
+        });
     } catch (err) {
         t.ifError(err);
         t.end();

--- a/test/async-await/async5.js
+++ b/test/async-await/async5.js
@@ -42,16 +42,14 @@ test('async5', async function myTest(t) {
         res.resume();
         t.equal(res.statusCode, 200);
 
-        await new Promise(function (resolve, reject) {
-            setTimeout(function () {
-                t.equal(mockDb.state, 'new');
+        setTimeout(function () {
+            t.equal(mockDb.state, 'new');
 
-                server.close(function (err) {
-                    if (err) { reject(err); }
-                    else { resolve(); }
-                });
-            }, 50);
-        });
+            server.close(function (err) {
+                t.ifError(err);
+                t.end();
+            });
+        }, 50);
     } catch (err) {
         t.ifError(err);
         t.end();

--- a/test/async-await/sync-error.js
+++ b/test/async-await/sync-error.js
@@ -1,0 +1,8 @@
+var test = require('../../');
+
+test('sync-error', function myTest(t) {
+    t.ok(true, 'before throw');
+    throw new Error('oopsie');
+    t.ok(true, 'after throw');
+    t.end();
+});


### PR DESCRIPTION
This PR adds rudimentary support for async/await in a fashion
that breaks back compat as little as possible.

Currently tape has no opinions about exception handling.
If you throw in a test block it will go straight to the
uncaught handler and exit the process.

However newer versions of node & v8 added async functions.
These functions when thrown return a rejected promise.

Currently node logs unhandled rejections with a warning
and in future versions of node, unhandled rejections may get
forwarded to uncaught exceptions.

This patch modifies tape so that an unhandled rejection will be 
marked as a TAP failure and fails the tests with exit code 1.

Previously on master it would log to STDERR and then continue
onwards running the rests of the tests.

For example :

```js
var tape = require('tape')

tape('my test', function (t) {
  // this causes the tests to fail with exit code 1
  t.oktypo(true, 'my bad')
})

tape('my async test', async function (t) {
  // on master : this causes the tests to pass with exit code 0 
  //     and STDERR noise about unhandled rejections
  // in this PR : this causes the tests to fail with exit code 1
  t.oktypo(true, 'my bad')
})
```

This patch is optional, there is a different work around you can do

```js
process.on('unhandledRejection', function (err) { throw err })

var tape = require('tape')

tape('my async test', async function (t) {
  // on master : this causes the tests to fail with exit code 1
  t.oktypo(true, 'my bad')
})
```

But adding that one liner to the top of every test file 
can get quite annoying and EASY to forget :(

Back compat is broken for some cases, only when the user of `tape` mixes promises & callbacks & async functions in a single `test` block. If the async function returns before you call `t.end()` ( aka you do not `await` the code that calls `t.end()`

However no back compat breaks for users that

 - do not use async/await
 - do not use promises
 - uses async/await but only with promises
 - uses promises and no callbacks
 - uses async/await, promises & callbacks but always does `await util.promisify((cb) { ...; t.end() }`