### PR TITLE
[Fix] emit skipped tests as objects

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -41,7 +41,9 @@ Results.prototype.createStream = function (opts) {
                 var row = {
                     type: 'test',
                     name: t.name,
-                    id: id
+                    id: id,
+                    skip: t._skip,
+                    todo: t._todo
                 };
                 if (has(extra, 'parent')) {
                     row.parent = extra.parent;
@@ -97,7 +99,10 @@ Results.prototype._watch = function (t) {
     var self = this;
     var write = function (s) { self._stream.queue(s); };
     t.once('prerun', function () {
-        write('# ' + t.name + '\n');
+        var premsg = '';
+        if (t._skip) premsg = 'SKIP ';
+        else if (t._todo) premsg = 'TODO ';
+        write('# ' + premsg + t.name + '\n');
     });
 
     t.on('result', function (res) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -83,16 +83,13 @@ function Test(name_, opts_, cb_) {
 }
 
 Test.prototype.run = function () {
-    if (this._skip) {
-        this.comment('SKIP ' + this.name);
-    }
+    this.emit('prerun');
     if (!this._cb || this._skip) {
         return this._end();
     }
     if (this._timeout != null) {
         this.timeoutAfter(this._timeout);
     }
-    this.emit('prerun');
     this._cb(this);
     this.emit('run');
 };

--- a/test/exit.js
+++ b/test/exit.js
@@ -155,7 +155,7 @@ tap.test('todo passing', function (t) {
     var tc = function (rows) {
         t.same(stripFullStack(rows.toString('utf8')), [
             'TAP version 13',
-            '# todo pass',
+            '# TODO todo pass',
             'ok 1 should be truthy # TODO',
             '',
             '1..1',
@@ -179,7 +179,7 @@ tap.test('todo failing', function (t) {
     var tc = function (rows) {
         t.same(stripFullStack(rows.toString('utf8')), [
             'TAP version 13',
-            '# todo fail',
+            '# TODO todo fail',
             'not ok 1 should be truthy # TODO',
             '  ---',
             '    operator: ok',

--- a/test/objectMode.js
+++ b/test/objectMode.js
@@ -1,0 +1,70 @@
+var tap = require('tap');
+var tape = require('../');
+var forEach = require('for-each');
+var through = require('through');
+
+tap.test('object results', function (assert) {
+    var printer = through({ objectMode: true });
+    var objects = [];
+
+    printer.write = function (obj) {
+        objects.push(obj);
+    };
+
+    printer.end = function (obj) {
+        if (obj) objects.push(obj);
+
+        var todos = 0;
+        var skips = 0;
+        var testIds = [];
+        var endIds = [];
+        var asserts = 0;
+
+        assert.equal(objects.length, 13);
+
+        forEach(objects, function (obj) {
+            if (obj.type === 'assert') {
+                asserts++;
+            } else if (obj.type === 'test') {
+                testIds.push(obj.id);
+
+                if (obj.skip) {
+                    skips++;
+                } else if (obj.todo) {
+                    todos++;
+                }
+            } else if (obj.type === 'end') {
+                endIds.push(obj.text);
+                // test object should exist
+                assert.notEqual(testIds.indexOf(obj.test), -1);
+            }
+        });
+
+        assert.equal(asserts, 5);
+        assert.equal(skips, 1);
+        assert.equal(todos, 2);
+        assert.equal(testIds.length, endIds.length);
+        assert.end();
+    };
+
+    tape.createStream({ objectMode: true })
+        .pipe(printer);
+
+    tape('parent', function (t1) {
+        t1.equal(true, true);
+        t1.test('child1', {skip: true}, function (t2) {
+            t2.equal(true, true);
+            t2.equal(true, false);
+            t2.end();
+        });
+        t1.test('child2', {todo: true}, function (t3) {
+            t3.equal(true, false);
+            t3.equal(true, true);
+            t3.end();
+        });
+        t1.test('child3', {todo: true});
+        t1.equal(true, true);
+        t1.equal(true, true);
+        t1.end();
+    });
+});

--- a/test/todo.js
+++ b/test/todo.js
@@ -15,7 +15,7 @@ tap.test('tape todo test', function (assert) {
             'TAP version 13\n'
             + '# success\n'
             + 'ok 1 this test runs\n'
-            + '# failure\n'
+            + '# TODO failure\n'
             + 'not ok 2 should never happen # TODO\n'
             + '  ---\n'
             + '    operator: fail\n'

--- a/test/todo_single.js
+++ b/test/todo_single.js
@@ -13,7 +13,7 @@ tap.test('tape todo test', function (assert) {
         assert.equal(
             stripFullStack(body.toString('utf8')),
             'TAP version 13\n'
-            + '# failure\n'
+            + '# TODO failure\n'
             + 'not ok 1 should be equal # TODO\n'
             + '  ---\n'
             + '    operator: equal\n'


### PR DESCRIPTION
When using `objectMode` skipped tests are emitted as comments, they are actual tests that need to be emitted as objects.

Test code:
``` js
const test = require('tape');
const printer = new require('stream').Writable({objectMode: true});
printer.write = printer.end = obj => {
  console.log(obj);
};

test.createStream({objectMode: true})
.pipe(printer);

test('parent', t => {
  t.equal(true, true);
  t.test('child1', {skip: 'not installed'}, t2 => {
    t2.equal(true, true);
    t2.equal(true, false);
    t2.end();
  });
  t.test('child2', {todo: 'will get done soon'}, t3 => {
    t3.equal(true, false);
    t3.equal(true, true);
    t3.end();
  });
  t.test('child3', {todo: 'will do'});
  t.equal(true, true);
  t.equal(true, true);
  t.end();
});
```

When used normally:
```
{ type: 'test', name: 'parent', id: 0 }
{
  id: 0,
  ok: true,
  skip: undefined,
  todo: false,
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: true,
  test: 0,
  type: 'assert'
}
{
  id: 1,
  ok: true,
  skip: undefined,
  todo: false,
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: true,
  test: 0,
  type: 'assert'
}
{
  id: 2,
  ok: true,
  skip: undefined,
  todo: false,
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: true,
  test: 0,
  type: 'assert'
}
SKIP child1                                                 <- plain text
{ type: 'end', test: 1 }                                    <- no object with testId 1
{ type: 'test', name: 'child2', id: 2, parent: 0 }
{
  id: 0,
  ok: false,
  skip: undefined,
  todo: 'will get done soon',
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: false,
  functionName: 'Test.<anonymous>',
  file: 'D:\\dev\\testing\\tape-test\\test.js:19:8',
  line: 19,
  column: 8,
  at: 'Test.<anonymous> (D:\\dev\\testing\\tape-test\\test.js:19:8)',
  test: 2,
  type: 'assert'
}
{
  id: 1,
  ok: true,
  skip: undefined,
  todo: 'will get done soon',
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: true,
  test: 2,
  type: 'assert'
}
{ type: 'end', test: 2 }
{ type: 'end', test: 3 }                                       <- no object with testId 3
{ type: 'end', test: 0 }
```

After patch:
```
{ type: 'test', name: 'parent', id: 0, skip: false, todo: false }
{
  id: 0,
  ok: true,
  skip: undefined,
  todo: false,
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: true,
  test: 0,
  type: 'assert'
}
{
  id: 1,
  ok: true,
  skip: undefined,
  todo: false,
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: true,
  test: 0,
  type: 'assert'
}
{
  id: 2,
  ok: true,
  skip: undefined,
  todo: false,
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: true,
  test: 0,
  type: 'assert'
}
{
  type: 'test',
  name: 'child1',
  id: 1,                                                         <- object with testId 1
  skip: 'not installed',
  todo: false,
  parent: 0
}
{ type: 'end', test: 1 }                                         <- reference exists
{
  type: 'test',
  name: 'child2',
  id: 2,
  skip: false,
  todo: 'will get done soon',
  parent: 0
}
{
  id: 0,
  ok: false,
  skip: undefined,
  todo: 'will get done soon',
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: false,
  functionName: 'Test.<anonymous>',
  file: 'D:\\dev\\testing\\tape-test\\test.js:19:8',
  line: 19,
  column: 8,
  at: 'Test.<anonymous> (D:\\dev\\testing\\tape-test\\test.js:19:8)',
  test: 2,
  type: 'assert'
}
{
  id: 1,
  ok: true,
  skip: undefined,
  todo: 'will get done soon',
  name: 'should be equal',
  operator: 'equal',
  objectPrintDepth: 5,
  actual: true,
  expected: true,
  test: 2,
  type: 'assert'
}
{ type: 'end', test: 2 }
{
  type: 'test',
  name: 'child3',
  id: 3,                                                         <- object with testId 3
  skip: false,
  todo: 'will do',
  parent: 0
}
{ type: 'end', test: 3 }                                         <- reference exists
{ type: 'end', test: 0 }
```