### PR TITLE
[Feat] Add descriptive messages for skipped asserts

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -16,6 +16,10 @@ var nextTick = typeof setImmediate !== 'undefined'
 module.exports = Results;
 inherits(Results, EventEmitter);
 
+function coalesceWhiteSpaces(str) {
+    return String(str).replace(/\s+/g, ' ');
+}
+
 function Results() {
     if (!(this instanceof Results)) return new Results;
     this.count = 0;
@@ -102,7 +106,7 @@ Results.prototype._watch = function (t) {
         var premsg = '';
         if (t._skip) premsg = 'SKIP ';
         else if (t._todo) premsg = 'TODO ';
-        write('# ' + premsg + t.name + '\n');
+        write('# ' + premsg + coalesceWhiteSpaces(t.name) + '\n');
     });
 
     t.on('result', function (res) {
@@ -142,10 +146,13 @@ Results.prototype.close = function () {
 function encodeResult(res, count) {
     var output = '';
     output += (res.ok ? 'ok ' : 'not ok ') + count;
-    output += res.name ? ' ' + res.name.toString().replace(/\s+/g, ' ') : '';
+    output += res.name ? ' ' + coalesceWhiteSpaces(res.name) : '';
 
-    if (res.skip) output += ' # SKIP';
-    else if (res.todo) output += ' # TODO';
+    if (res.skip) {
+        output += ' # SKIP' + ((typeof res.skip === 'string') ? ' ' + coalesceWhiteSpaces(res.skip) : '');
+    } else if (res.todo) {
+        output += ' # TODO' + ((typeof res.todo === 'string') ? ' ' + coalesceWhiteSpaces(res.todo) : '');
+    };
 
     output += '\n';
     if (res.ok) return output;

--- a/lib/test.js
+++ b/lib/test.js
@@ -202,6 +202,8 @@ Test.prototype._assert = function assert(ok, opts) {
     var self = this;
     var extra = opts.extra || {};
 
+    ok = Boolean(ok) || Boolean(extra.skip);
+
     var res = {
         id: self.assertCount++,
         ok: Boolean(ok),

--- a/test/skip_explanation.js
+++ b/test/skip_explanation.js
@@ -1,0 +1,82 @@
+var tap = require('tap');
+var test = require('../');
+var concat = require('concat-stream');
+var stripFullStack = require('./common').stripFullStack;
+
+tap.test('test skip explanations', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(stripFullStack(output.toString('utf8')), [
+            'TAP version 13',
+            '# SKIP (this skips)',
+            '# some tests might skip',
+            'ok 1 this runs',
+            'ok 2 failing assert is skipped # SKIP',
+            'ok 3 this runs',
+            '# incomplete test',
+            'ok 4 run sh',
+            'ok 5 run openssl # SKIP',
+            '# incomplete test with explanation',
+            'ok 6 run sh (conditional skip) # SKIP',
+            'ok 7 run openssl # SKIP can\'t run on windows platforms',
+            'ok 8 this runs',
+            '# too much explanation',
+            'ok 9 run openssl # SKIP Installer cannot work on windows and fails to add to PATH Err: (2401) denied',
+            '',
+            '1..9',
+            '# tests 9',
+            '# pass  9',
+            '',
+            '# ok',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness();
+    tapeTest.createStream().pipe(concat(verify));
+
+    tapeTest('(this skips)', { skip: true }, function (t) {
+        t.fail('doesn\'t run');
+        t.fail('this doesn\'t run too', { skip: false });
+        t.end();
+    });
+
+    tapeTest('some tests might skip', function (t) {
+        t.pass('this runs');
+        t.fail('failing assert is skipped', { skip: true });
+        t.pass('this runs');
+        t.end();
+    });
+
+    tapeTest('incomplete test', function (t) {
+        // var platform = process.platform; something like this needed
+        var platform = 'win32';
+
+        t.pass('run sh', { skip: platform !== 'win32' });
+        t.pass('run openssl', { skip: platform === 'win32' });
+        t.end();
+    });
+
+    tapeTest('incomplete test with explanation', function (t) {
+        // var platform = process.platform; something like this needed
+        var platform = 'win32';
+
+        t.fail('run sh (conditional skip)', { skip: platform === 'win32' });
+        t.fail('run openssl', { skip: platform === 'win32' && 'can\'t run on windows platforms' });
+        t.pass('this runs');
+        t.end();
+    });
+
+    tapeTest('too much explanation', function (t) {
+        // var platform = process.platform; something like this needed
+        var platform = 'win32';
+
+        t.fail('run openssl',
+            { skip: platform === 'win32' && 'Installer cannot work on windows\nand fails to add to PATH\n\n Err: (2401) denied' }
+        );
+        t.end();
+    });
+});
+
+// vim: set softtabstop=4 shiftwidth=4:

--- a/test/todo_explanation.js
+++ b/test/todo_explanation.js
@@ -1,0 +1,70 @@
+var tap = require('tap');
+var tape = require('../');
+var concat = require('concat-stream');
+
+var common = require('./common');
+var stripFullStack = common.stripFullStack;
+
+tap.test('tape todo test', { todo: process.versions.node.match(/0\.8\.\d+/) ? 'Fails on node 0.8': false }, function (assert) {
+    var test = tape.createHarness({ exit: false });
+    assert.plan(1);
+
+    test.createStream().pipe(concat(function (body) {
+        assert.equal(
+            stripFullStack(body.toString('utf8')), [
+                'TAP version 13',
+                '# success',
+                'ok 1 this test runs',
+                '# TODO incomplete test1',
+                'not ok 2 check output # TODO',
+                '  ---',
+                '    operator: equal',
+                '    expected: false',
+                '    actual:   true',
+                '    at: Test.<anonymous> ($TEST/todo_explanation.js:$LINE:$COL)',
+                '  ...',
+                'not ok 3 check vars output # TODO name conflict',
+                '  ---',
+                '    operator: equal',
+                '    expected: 0',
+                '    actual:   1',
+                '    at: Test.<anonymous> ($TEST/todo_explanation.js:$LINE:$COL)',
+                '  ...',
+                '# incomplete test2',
+                'not ok 4 run openssl # TODO installer needs fix',
+                '  ---',
+                '    operator: fail',
+                '    at: Test.<anonymous> ($TEST/todo_explanation.js:$LINE:$COL)',
+                '  ...',
+                '# TODO passing test',
+                '',
+                '1..4',
+                '# tests 4',
+                '# pass  4',
+                '',
+                '# ok',
+                ''
+            ].join('\n')
+        );
+    }));
+
+    test('success', function (t) {
+        t.equal(true, true, 'this test runs');
+        t.end();
+    });
+
+    test('incomplete test1', { todo: true }, function (t) {
+        t.equal(true, false, 'check output');
+        t.equal(1, 0, 'check vars output', { todo: 'name conflict' });
+        t.end();
+    });
+
+    test('incomplete test2', function (t) {
+        t.fail('run openssl', { todo: 'installer needs fix' });
+        t.end();
+    });
+
+    test('passing test', { todo: 'yet incomplete' }, function (t) {
+        t.end();
+    });
+});


### PR DESCRIPTION
Now asserts can take `skip` as a `string` or `boolean`, strings get printed as the reason for skipping the assert.

```
(ok|not ok) 3 <assert message> # SKIP <reason for skipping>
```