### PR TITLE
add tap-nyc to pretty-reporters

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -116,6 +116,7 @@ that will output something pretty if you pipe TAP into them:
 - [tap-html](https://github.com/gabrielcsapo/tap-html)
 - [tap-react-browser](https://github.com/mcnuttandrew/tap-react-browser)
 - [tap-junit](https://github.com/dhershman1/tap-junit)
+- [tap-nyc](https://github.com/MegaArman/tap-nyc)
 
 To use them, try `node test/index.js | tap-spec` or pipe it into one
 of the modules of your choice!


### PR DESCRIPTION
tap-nyc is intended for use with both tape and the [nyc](https://github.com/istanbuljs/nyc) code coverage module. When trying to use both, other formatters tend to produce either weird looking output or output with errors all together.

Closes #371