### PR TITLE
 Report skipped assertions

### DIFF
--- a/lib/results.js
+++ b/lib/results.js
@@ -25,6 +25,7 @@ function Results() {
     this.count = 0;
     this.fail = 0;
     this.pass = 0;
+    this.skip = 0;
     this.todo = 0;
     this._stream = through();
     this.tests = [];
@@ -104,6 +105,7 @@ Results.prototype._watch = function (t) {
     var write = function (s) { self._stream.queue(s); };
     t.once('prerun', function () {
         var premsg = '';
+        if (t._skip) self.skip ++;
         if (t._skip) premsg = 'SKIP ';
         else if (t._todo) premsg = 'TODO ';
         write('# ' + premsg + coalesceWhiteSpaces(t.name) + '\n');
@@ -117,6 +119,7 @@ Results.prototype._watch = function (t) {
         write(encodeResult(res, self.count + 1));
         self.count ++;
 
+        if (res.skip) self.skip ++;
         if (res.ok || res.todo) self.pass ++;
         else {
             self.fail ++;
@@ -136,6 +139,7 @@ Results.prototype.close = function () {
     write('\n1..' + self.count + '\n');
     write('# tests ' + self.count + '\n');
     write('# pass  ' + (self.pass + self.todo) + '\n');
+    if (self.skip) write('# skip  ' + self.skip + '\n');
     if (self.todo) write('# todo  ' + self.todo + '\n');
     if (self.fail) write('# fail  ' + self.fail + '\n');
     else write('\n# ok\n');

--- a/lib/test.js
+++ b/lib/test.js
@@ -544,10 +544,10 @@ Test.prototype.doesNotThrow = function (fn, expected, msg, extra) {
     });
 };
 
-Test.skip = function (name_, _opts, _cb) {
-    var args = getTestArgs.apply(null, arguments);
+Test.skip = function (name_, opts_, cb_) {
+    var args = getTestArgs(name_, opts_, cb_);
     args.opts.skip = true;
-    return Test(args.name, args.opts, args.cb);
+    return new Test(args.name, args.opts, args.cb);
 };
 
 // vim: set softtabstop=4 shiftwidth=4:

--- a/test/skip.js
+++ b/test/skip.js
@@ -15,6 +15,7 @@ tap.test('test SKIP comment', function (assert) {
             '1..0',
             '# tests 0',
             '# pass  0',
+            '# skip  1',
             '',
             '# ok',
             ''

--- a/test/skip_explanation.js
+++ b/test/skip_explanation.js
@@ -27,6 +27,7 @@ tap.test('test skip explanations', function (assert) {
             '1..9',
             '# tests 9',
             '# pass  9',
+            '# skip  6',
             '',
             '# ok',
             ''

--- a/test/skip_output.js
+++ b/test/skip_output.js
@@ -1,0 +1,59 @@
+var test = require('../');
+
+var concat = require('concat-stream');
+var tap = require('tap');
+
+tap.test('skip output test', function (assert) {
+    assert.plan(1);
+
+    var verify = function (output) {
+        assert.equal(output.toString('utf8'), [
+            'TAP version 13',
+            '# SKIP we require more vespene gas',
+            '# skip assertions',
+            'ok 1 not enough pylons # SKIP',
+            '# skip subtests',
+            '# SKIP we require more ziggurats',
+            '',
+            '1..1',
+            '# tests 1',
+            '# pass  1',
+            '# skip  3',
+            '',
+            '# ok',
+            ''
+        ].join('\n'));
+    };
+
+    var tapeTest = test.createHarness({ exit: false });
+    tapeTest.createStream().pipe(concat(verify));
+
+    // doesn't look like test.skip is available with createHarness()
+    // tapeTest.skip('we require more minerals', function (t) {
+    //     t.plan(1);
+    //     t.fail('should not fail test.skip()');
+    // });
+
+    tapeTest('we require more vespene gas', { skip: true }, function (t) {
+        t.plan(1);
+        t.fail('should not fail test with { skip: true}');
+    });
+
+    tapeTest('skip assertions', function (t) {
+        t.plan(1);
+        t.skip('not enough pylons');
+    });
+
+    tapeTest('skip subtests', function (t) {
+        // doesn't look like test.skip is available with createHarness()
+        // test.skip('build more farms', function (t) {
+        //     t.plan(1)
+        //     t.fail('should not run subtest with test.skip()');
+        // });
+        t.test('we require more ziggurats', { skip: true }, function (tt) {
+            tt.plan(1);
+            tt.fail('should not run subtest with { skip: true }');
+        });
+        t.end();
+    });
+});


### PR DESCRIPTION
-  include the count of skipped tests in the generated output
- resolve an issue where `test.skip(fn, cb)` would behave differently from `test(fn, { skip: true }, cb)` and not mark the tests with prefix `# SKIP`

This is a rebase and simplification of https://github.com/substack/tape/pull/197

