### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "nodejs"
-run = "yarn install && cd example && node array.js"
+run = "npm install && cd example && node array.js"

--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn install && cd example && node array.js"

--- a/readme.markdown
+++ b/readme.markdown
@@ -8,6 +8,8 @@ tap-producing test harness for node and browsers
 
 ![tape](https://web.archive.org/web/20170612184731if_/http://substack.net/images/tape_drive.png)
 
+[![run on repl.it](http://repl.it/badge/github/substack/tape)](https://repl.it/github/substack/tape)
+
 # example
 
 ``` js


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-tape):

![image](https://i.imgur.com/JNE4Hyj.png)
