### PR TITLE
When t.end() is not called, print the name.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -214,7 +214,7 @@ Test.prototype._exit = function () {
             exiting: true
         });
     } else if (!this.ended) {
-        this.fail('test exited without ending', {
+        this.fail('test exited without ending: ' + this.name, {
             exiting: true
         });
     }

--- a/test/exit.js
+++ b/test/exit.js
@@ -204,3 +204,36 @@ tap.test('todo failing', function (t) {
         t.equal(code, 0);
     });
 });
+
+tap.test('forgot to call t.end()', function (t) {
+    t.plan(2);
+
+    var tc = function (rows) {
+        t.same(stripFullStack(rows.toString('utf8')), [
+            'TAP version 13',
+            '# first',
+            'ok 1 should be truthy',
+            '# oops forgot end',
+            'ok 2 should be truthy',
+            'not ok 3 test exited without ending: oops forgot end',
+            '  ---',
+            '    operator: fail',
+            '    at: process.<anonymous> ($TAPE/index.js:$LINE:$COL)',
+            '    stack: |-',
+            '      Error: test exited without ending: oops forgot end',
+            '          [... stack stripped ...]',
+            '  ...',
+            '',
+            '1..3',
+            '# tests 3',
+            '# pass  2',
+            '# fail  1'
+        ].join('\n') + '\n\n');
+    };
+
+    var ps = spawn(process.execPath, [path.join(__dirname, '/exit/missing_end.js')]);
+    ps.stdout.pipe(concat(tc));
+    ps.on('exit', function (code) {
+        t.notEqual(code, 0);
+    });
+});

--- a/test/exit/missing_end.js
+++ b/test/exit/missing_end.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var test = require('../../');
+
+test('first', function (t) {
+    t.ok(true);
+    t.end();
+});
+
+test('oops forgot end', function (t) {
+    t.ok(true);
+});


### PR DESCRIPTION
If you forget to call `t.end()` on some test somewhere
and all the other tests pass then you will get a warning
about not having called t.end().

This warning misses which tests should have ended.