### PR TITLE
Propose an optional emoji version for tap-spec consumer

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -115,6 +115,7 @@ that will output something pretty if you pipe TAP into them:
 - [tap-react-browser](https://github.com/mcnuttandrew/tap-react-browser)
 - [tap-junit](https://github.com/dhershman1/tap-junit)
 - [tap-nyc](https://github.com/MegaArman/tap-nyc)
+- [tap-spec (emoji patch)](https://github.com/Sceat/tap-spec-emoji)
 
 To use them, try `node test/index.js | tap-spec` or pipe it into one
 of the modules of your choice!


### PR DESCRIPTION
## Patch Motivation

Using a terminal with emoji support, the tests output become pretty ugly. This package use different emojis instead.

## Why not a PR
You may still use the original lib for your CI in case it doesn't support emojis (because it support char fallbacks), but on your local computer this version allow for a better output

### Original

![](https://i.imgur.com/yNCoue7.png)

### Patched

![](https://i.imgur.com/CDiF3bE.png)