### PR TITLE
upgrade the dependencies to their latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "through": "^2.3.8"
     },
     "devDependencies": {
-        "concat-stream": "^1.6.2",
+        "concat-stream": "^2.0.0",
         "eclint": "^2.8.1",
         "ecstatic": "^4.1.4",
         "eslint": "^6.8.0",
@@ -51,7 +51,7 @@
         "tap-parser": "^3.0.5"
     },
     "scripts": {
-        "prelint": "eclint check",
+        "prelint": "eclint check **/*.js",
         "lint": "eslint . bin/*",
         "pretest": "npm run lint",
         "test": "npm run tests-only",


### PR DESCRIPTION
This pr upgrades `tap` and `tap-parser` to their latest version. I also tool the opportunity to upgrade `concat-stream`.

Looking forward to any feedback.

Few notable upstream changes:
- `tap-parser` changed the signature - requiring us to create a class with `new` keyword
- `tap-parser` added a parser.fullname field - 
https://github.com/tapjs/tap-parser/commit/287e137f0dc5854acc636d1f0f46f4ff423db4b4 - my approach in this PR is to explicitly delete the `parser.fullname` property, but I can change the *expectations* too if that's more preferred.