### PR TITLE
add tape-describe to readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -134,6 +134,7 @@ By default, uncaught exceptions in your tests will not be intercepted, and will 
 - Electron test runner with https://github.com/tundrax/electron-tap
 - Concurrency support with https://github.com/imsnif/mixed-tape
 - In-process reporting with https://github.com/DavidAnson/tape-player
+- Describe blocks with https://github.com/mattriley/tape-describe
 
 # methods
 


### PR DESCRIPTION
Added tape-describe to "other" section in the readme, as raised at https://github.com/substack/tape/issues/522