### PR TITLE
Include name of test in log when test times out

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -159,7 +159,7 @@ Test.prototype.timeoutAfter = function (ms) {
     if (!ms) throw new Error('timeoutAfter requires a timespan');
     var self = this;
     var timeout = safeSetTimeout(function () {
-        self.fail('test timed out after ' + ms + 'ms');
+        self.fail(self.name + ' timed out after ' + ms + 'ms');
         self.end();
     }, ms);
     this.once('end', function () {

--- a/test/timeoutAfter.js
+++ b/test/timeoutAfter.js
@@ -14,11 +14,11 @@ tap.test('timeoutAfter test', function (tt) {
         tt.same(stripFullStack(rows.toString('utf8')), [
             'TAP version 13',
             '# timeoutAfter',
-            'not ok 1 test timed out after 1ms',
+            'not ok 1 timeoutAfter timed out after 1ms',
             '  ---',
             '    operator: fail',
             '    stack: |-',
-            '      Error: test timed out after 1ms',
+            '      Error: timeoutAfter timed out after 1ms',
             '          [... stack stripped ...]',
             '  ...',
             '',


### PR DESCRIPTION
It can be difficult to tell which test has timed out by looking at the logs since the log is hardcoded as `test timed out after...`. This PR includes the test name in the log to make it more explicit what timed out.