### PR TITLE
fix: fixed package path not exported: ./bin/tape

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "./lib/results": "./lib/results.js",
         "./lib/test": "./lib/test.js",
         "./package": "./package.json",
-        "./package.json": "./package.json"
+        "./package.json": "./package.json",
+		"./bin/tape": "./bin/tape"
     },
     "bin": "./bin/tape",
     "directories": {


### PR DESCRIPTION
I was having an error every time I would use a package that included tape regarding an export that would prevent me from continuing my pipelines.

The error was `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './bin/tape' is not defined by "exports" in .../node_modules/tape/package.json`

This is a simple fix for that issue.