### PR TITLE
Correct esm problem on windows

### DIFF
--- a/bin/import-or-require.js
+++ b/bin/import-or-require.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { extname: extnamePath } = require('path');
+const { pathToFileURL } = require('url');
 const getPackageType = require('get-package-type');
 
 // eslint-disable-next-line consistent-return
@@ -8,7 +9,7 @@ module.exports = function importOrRequire(file) {
     const ext = extnamePath(file);
 
     if (ext === '.mjs' || (ext === '.js' && getPackageType.sync(file) === 'module')) {
-        return import(file);
+        return import(pathToFileURL(file).href);
     }
     require(file);
 };


### PR DESCRIPTION
When using tape on windows in a esm module (using `"type": "module"` in the project package.json),  this exception is raised:

```
(node:7484) UnhandledPromiseRejectionWarning: Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are
supported by the default ESM loader
    at Loader.defaultResolve [as _resolve] (internal/modules/esm/resolve.js:698:11)
    at Loader.resolve (internal/modules/esm/loader.js:97:40)
    at Loader.getModuleJob (internal/modules/esm/loader.js:243:28)
    at Loader.import (internal/modules/esm/loader.js:178:28)
    at importModuleDynamically (internal/modules/cjs/loader.js:1080:27)
    at exports.importModuleDynamicallyCallback (internal/process/esm_loader.js:37:14)
    at importOrRequire (C:\...\tests\node_modules\tape\bin\import-or-require.js:11:9)       
    at C:\...\tests\node_modules\tape\bin\tape:84:14
    at Array.reduce (<anonymous>)
    at importFiles (C:\...\tests\node_modules\tape\bin\tape:81:30)
```
In turns out that making explicit the file protocol in the importOrRequire resolves this problem.