### PR TITLE
[meta] Exclude `fs` from browser bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "5.3.1",
     "description": "tap-producing test harness for node and browsers",
     "main": "index.js",
+    "browser": {
+        "fs": false
+    },
     "exports": {
         ".": [
             {


### PR DESCRIPTION
As suggested in https://github.com/substack/tape/issues/561#issuecomment-909469015 and verified in https://github.com/substack/tape/issues/561#issuecomment-917700972

In short this change will let:

- webpack 4 users bundle without any configuration
- webpack 5 users remove 1 line of config 😅 
- other bundlers to skip looking for the `fs` dependency altogether