### PR TITLE
doc: remove link to ES6 support runners

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -141,7 +141,6 @@ By default, uncaught exceptions in your tests will not be intercepted, and will 
 ## other
 
 - CoffeeScript support with https://www.npmjs.com/package/coffeetape
-- ES6 support with https://www.npmjs.com/package/babel-tape-runner or https://www.npmjs.com/package/buble-tape-runner
 - Different test syntax with https://github.com/pguth/flip-tape (warning: mutates String.prototype)
 - Electron test runner with https://github.com/tundrax/electron-tap
 - Concurrency support with https://github.com/imsnif/mixed-tape


### PR DESCRIPTION
Now that `tape` itself supports ES6, there is no need for “ES6 support with https://www.npmjs.com/package/babel-tape-runner or https://www.npmjs.com/package/buble-tape-runner” anymore, so this item becomes misleading (suggests to the newcomer that `tape` still doesn't support ES6).

Unless I'm wrong and there _is_ still some reason to use them? If so, maybe specify that reason.