### PR TITLE
[Fix] use `file://` URLs for dynamic `import()`

### DIFF
--- a/bin/import-or-require.js
+++ b/bin/import-or-require.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { extname: extnamePath } = require('path');
+const { pathToFileURL } = require('url');
 const getPackageType = require('get-package-type');
 
 // eslint-disable-next-line consistent-return
@@ -8,7 +9,7 @@ module.exports = function importOrRequire(file) {
     const ext = extnamePath(file);
 
     if (ext === '.mjs' || (ext === '.js' && getPackageType.sync(file) === 'module')) {
-        return import(file);
+        return import(pathToFileURL(file).href);
     }
     require(file);
 };


### PR DESCRIPTION
Alternative to #559.

This is required on Windows if the argument passed to `import()` is an absolute path. Without it `tape test.js` fails if test.js is ESM.

Covered by existing tests: `node test/import.js` fails without this (as well as some other tests but those seem less relevant to the issue at hand).

See https://github.com/nodejs/node/commit/a0846326dd42bf4ec2f91df9cade762283567511