### PR TITLE
[Refactor] Use `globv7` instead of old glob 7.2.3

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -57,7 +57,7 @@ if (ignoreStr) {
 	matcher = ignore.createMatcher(ignoreStr);
 }
 
-var glob = require('glob');
+var glob = require('globv7');
 
 var files = opts._.reduce(function (result, arg) {
 	if (glob.hasMagic(arg)) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"dotignore": "^0.1.2",
 		"for-each": "^0.3.5",
 		"get-package-type": "^0.1.0",
-		"glob": "^7.2.3",
+		"globv7": "^1.0.0",
 		"has-dynamic-import": "^2.1.1",
 		"hasown": "^2.0.2",
 		"inherits": "^2.0.4",


### PR DESCRIPTION
The glob package (v7.2.3) currently used is deprecated. While it functions, it is no longer receiving security patches or bug fixes from the original author, who has moved on to v8+.

Moving tape to glob v8/v9/v10 would require a significant refactor because those versions are now promise-based and have different API signatures, and it would also break backwards compatibility.

Solution: I've switched the dependency to globv7. This is a maintained fork of the original glob v7.2.3 logic. It’s a drop-in replacement that preserves the synchronous/callback behavior tape relies on. It provides a path for security patches if vulnerabilities are found in the v7 logic without forcing a breaking change on this repository.

My fork maintains the same backwards compatibility and API

I did not use AI to generate any part of the code for this change.

